### PR TITLE
fix(ci): establish baseline benchmarks for performance tracking

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -2,6 +2,8 @@
 
 This document describes the benchmarking infrastructure for Serpen, designed to track performance regressions and ensure consistent bundling performance.
 
+<!-- Baseline establishment trigger: This change establishes initial benchmarks -->
+
 ## Overview
 
 Serpen uses [Bencher.dev](https://bencher.dev) with [Criterion.rs](https://github.com/bheisler/criterion.rs) and [Hyperfine](https://github.com/sharkdp/hyperfine) for comprehensive benchmarking with three layers of integration:


### PR DESCRIPTION
## Summary

This PR establishes initial baseline benchmarks for the performance tracking infrastructure added in #75.

## Problem

After merging the benchmarking infrastructure, the base branch workflows haven't run yet to establish initial baselines in Bencher.dev. This causes PR #76 and future PRs to fail when trying to compare against non-existent baselines.

## Solution

This change triggers the `base_benchmarks.yml` workflow by creating a minimal documentation update. When this PR is created, it will:

1. Run the PR benchmark workflow (without baseline comparison)
2. When merged to main, trigger the base benchmark workflow
3. Establish initial performance baselines in Bencher.dev
4. Allow future PRs to properly compare against established baselines

## Changes

- Add a documentation comment to trigger workflow execution
- No functional changes to the codebase

## Expected Workflow

1. **PR Creation**: Triggers `pr_benchmarks.yml` (no baseline comparison needed)
2. **PR Merge**: Triggers `base_benchmarks.yml` on main branch
3. **Baseline Establishment**: Creates initial benchmark data in Bencher.dev
4. **Future PRs**: Can now compare against established baselines

This solves the chicken-and-egg problem of needing baseline data before PRs can use performance comparison features.

🤖 Generated with [Claude Code](https://claude.ai/code)