### PR TITLE
fix(ci): restore start-point parameters for proper PR benchmarking

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -48,6 +48,10 @@ jobs:
           --project cribo \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch "$GITHUB_HEAD_REF" \
+          --start-point "$GITHUB_BASE_REF" \
+          --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+          --start-point-clone-thresholds \
+          --start-point-reset \
           --testbed ubuntu-latest \
           --err \
           --adapter rust_criterion \


### PR DESCRIPTION
## Summary
- Restore essential `--start-point` parameters in PR benchmarking workflow
- Enable proper performance regression detection now that baselines are established

## Context
After establishing base benchmarks on the main branch (PR #77), we can now restore the start-point parameters that were previously removed due to missing baselines. These parameters are crucial for accurate PR benchmark comparisons.

## Changes
Added back the following parameters to `.github/workflows/pr_benchmarks.yml`:
- `--start-point "$GITHUB_BASE_REF"` - Compare against base branch (main)
- `--start-point-hash '${{ github.event.pull_request.base.sha }}'` - Use specific commit hash for precise comparison
- `--start-point-clone-thresholds` - Copy performance thresholds from main branch  
- `--start-point-reset` - Prevent benchmark data drift

## Benefits
✅ **Accurate regression detection**: Compare PR performance against established baselines
✅ **Statistical thresholds**: Inherit proper performance thresholds from main branch
✅ **Data integrity**: Prevent benchmark data drift between branches
✅ **Precise comparisons**: Use exact commit hashes for reproducible results

## Test plan
- [x] Verify parameters align with [Bencher.dev GitHub Actions best practices](https://bencher.dev/docs/how-to/github-actions/)
- [ ] Test PR workflow with these parameters restored
- [ ] Confirm proper benchmark comparisons appear in PR comments

This completes the benchmarking infrastructure setup that began with PR #75 and PR #77.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow for benchmarking pull requests. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->