### PR TITLE
feat(test): re-enable single dot relative import test

### DIFF
--- a/crates/serpen/tests/snapshots/stickytape_compatibility_tests__bundled_explicit_relative_import_single_dot_in_init.snap
+++ b/crates/serpen/tests/snapshots/stickytape_compatibility_tests__bundled_explicit_relative_import_single_dot_in_init.snap
@@ -7,13 +7,12 @@ description: Bundled content for explicit_relative_import_single_dot_in_init
 # https://github.com/tinovyatkin/serpen
 
 # ─ Module: greetings.greeting ─
-__greetings_greeting_message = "Hello"
-message = __greetings_greeting_message
+message = "Hello"
 
 # ─ Module: greetings ─
 import types
 greetings = types.ModuleType('greetings')
-exec('__all__ = ["message"]\nmessage = __greetings_greeting_message', globals(), greetings.__dict__)
+exec('__all__ = ["message"]\nmessage = message', globals(), greetings.__dict__)
 
 # ─ Entry Module: hello ─
 print(greetings.message)

--- a/crates/serpen/tests/stickytape_compatibility_tests.rs
+++ b/crates/serpen/tests/stickytape_compatibility_tests.rs
@@ -201,7 +201,6 @@ fn test_explicit_relative_imports_with_single_dot_are_resolved_correctly() {
 }
 
 #[test]
-#[ignore = "Needs module object creation for 'from . import module' cases"]
 fn test_explicit_relative_imports_with_single_dot_in_package_init_are_resolved_correctly() {
     assert_script_output("explicit_relative_import_single_dot_in_init", "Hello");
 }


### PR DESCRIPTION
## Summary

Re-enable the previously ignored test `test_explicit_relative_imports_with_single_dot_in_package_init_are_resolved_correctly` that validates handling of `from . import module` syntax in package `__init__.py` files.

## Changes

- ✅ Removed `#[ignore]` annotation from the test in `stickytape_compatibility_tests.rs:204`
- ✅ Updated snapshot to reflect current correct bundling behavior
- ✅ Verified test passes and produces expected "Hello" output

## Technical Details

The test was functionally working but failing on snapshot comparison. Investigation revealed:

- **Previous behavior**: Used conflict-based variable renaming pattern
- **Current behavior**: Uses cleaner module object creation with direct variable references

The current implementation correctly handles relative imports by:
1. Creating proper module objects using `types.ModuleType`
2. Using `exec()` to populate module namespaces
3. Maintaining direct variable references without unnecessary renaming

## Test Results

- ✅ All tests pass including the newly enabled test
- ✅ No clippy warnings
- ✅ Bundled output produces correct "Hello" output when executed
- ✅ Snapshot reflects cleaner, more maintainable approach

🤖 Generated with [Claude Code](https://claude.ai/code)