### PR TITLE
feat(cli): add verbose flag repetition support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,31 @@ cargo build --release
 
 # Run the tool directly
 cargo run --package cribo --bin cribo -- --entry path/to/main.py --output bundle.py
+
+# Run with verbose output for debugging
+cargo run --package cribo --bin cribo -- --entry path/to/main.py --output bundle.py -vv
+
+# Run with trace-level output for detailed debugging
+cargo run --package cribo --bin cribo -- --entry path/to/main.py --output bundle.py -vvv
 ```
+
+### CLI Usage
+
+```bash
+cribo --entry src/main.py --output bundle.py [options]
+
+# Common options
+--emit-requirements    # Generate requirements.txt with third-party dependencies
+-v, --verbose...       # Increase verbosity (can be repeated: -v, -vv, -vvv)
+                       # No flag: warnings/errors only
+                       # -v: informational messages  
+                       # -vv: debug messages
+                       # -vvv: trace messages
+--config               # Specify custom config file path
+--target-version       # Target Python version (e.g., py38, py39, py310, py311, py312, py313)
+```
+
+The verbose flag is particularly useful for debugging bundling issues. Each level provides progressively more detail about the bundling process, import resolution, and dependency graph construction.
 
 ### Testing Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,12 @@ cargo build --release
 
 # Run the tool directly
 cargo run -- --entry path/to/main.py --output bundle.py
+
+# Run with verbose output for debugging
+cargo run -- --entry path/to/main.py --output bundle.py -vv
+
+# Run with trace-level output for detailed debugging
+cargo run -- --entry path/to/main.py --output bundle.py -vvv
 ```
 
 #### Python Package
@@ -547,8 +553,13 @@ cribo --entry src/main.py --output bundle.py [options]
 
 # Common options
 --emit-requirements    # Generate requirements.txt with third-party dependencies
---verbose              # Enable verbose logging
+-v, --verbose...       # Increase verbosity (can be repeated: -v, -vv, -vvv)
+                       # No flag: warnings/errors only
+                       # -v: informational messages  
+                       # -vv: debug messages
+                       # -vvv: trace messages
 --config               # Specify custom config file path
+--target-version       # Target Python version (e.g., py38, py39, py310, py311, py312, py313)
 ```
 
 ### Development Guidelines

--- a/README.md
+++ b/README.md
@@ -106,11 +106,54 @@ cribo --entry src/main.py --output bundle.py
 # Generate requirements.txt
 cribo --entry src/main.py --output bundle.py --emit-requirements
 
-# Verbose output
-cribo --entry src/main.py --output bundle.py --verbose
+# Verbose output (can be repeated for more detail: -v, -vv, -vvv)
+cribo --entry src/main.py --output bundle.py -v
+cribo --entry src/main.py --output bundle.py -vv    # debug level
+cribo --entry src/main.py --output bundle.py -vvv   # trace level
 
 # Custom config file
 cribo --entry src/main.py --output bundle.py --config my-cribo.toml
+```
+
+### CLI Options
+
+- `-e, --entry <PATH>`: Entry point Python script (required)
+- `-o, --output <PATH>`: Output bundled Python file (required)
+- `-v, --verbose...`: Increase verbosity level. Can be repeated for more detail:
+  - No flag: warnings and errors only
+  - `-v`: informational messages
+  - `-vv`: debug messages
+  - `-vvv` or more: trace messages
+- `-c, --config <PATH>`: Custom configuration file path
+- `--emit-requirements`: Generate requirements.txt with third-party dependencies
+- `--target-version <VERSION>`: Target Python version (e.g., py38, py39, py310, py311, py312, py313)
+- `-h, --help`: Print help information
+- `-V, --version`: Print version information
+
+The verbose flag is particularly useful for debugging bundling issues. Each level provides progressively more detail:
+
+```bash
+# Default: only warnings and errors
+cribo --entry main.py --output bundle.py
+
+# Info level: shows progress messages
+cribo --entry main.py --output bundle.py -v
+
+# Debug level: shows detailed processing steps
+cribo --entry main.py --output bundle.py -vv
+
+# Trace level: shows all internal operations
+cribo --entry main.py --output bundle.py -vvv
+```
+
+The verbose levels map directly to Rust's log levels and can also be controlled via the `RUST_LOG` environment variable for more fine-grained control:
+
+```bash
+# Equivalent to -vv
+RUST_LOG=debug cribo --entry main.py --output bundle.py
+
+# Module-specific logging
+RUST_LOG=cribo::bundler=trace,cribo::resolver=debug cribo --entry main.py --output bundle.py
 ```
 
 ## Configuration

--- a/crates/cribo/src/main.rs
+++ b/crates/cribo/src/main.rs
@@ -17,9 +17,9 @@ struct Cli {
     #[arg(short, long)]
     output: PathBuf,
 
-    /// Enable verbose logging
-    #[arg(short, long)]
-    verbose: bool,
+    /// Increase verbosity (can be repeated: -v, -vv, -vvv)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 
     /// Configuration file path
     #[arg(short, long)]
@@ -37,10 +37,19 @@ struct Cli {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    // Initialize logging
-    let log_level = if cli.verbose { "debug" } else { "info" };
+    // Initialize logging based on verbosity level
+    let log_level = match cli.verbose {
+        0 => "warn",  // Default: warnings and errors only
+        1 => "info",  // -v: informational messages
+        2 => "debug", // -vv: debug messages
+        _ => "trace", // -vvv or more: trace messages
+    };
     env_logger::Builder::from_env(Env::default().default_filter_or(log_level)).init();
 
+    debug!(
+        "Verbosity level: {} (log level: {})",
+        cli.verbose, log_level
+    );
     info!("Starting Cribo Python bundler");
 
     debug!("Entry point: {:?}", cli.entry);

--- a/crates/cribo/tests/test_cli_verbose.rs
+++ b/crates/cribo/tests/test_cli_verbose.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+#[test]
+fn test_verbose_flag_help() {
+    // Test that the help text shows the correct verbose flag description
+    let output = Command::new("cargo")
+        .args(["run", "--bin", "cribo", "--", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("-v, --verbose..."));
+    assert!(stdout.contains("Increase verbosity (can be repeated: -v, -vv, -vvv)"));
+}
+
+#[test]
+fn test_verbose_flag_parsing() {
+    // Test that multiple verbose flags are accepted
+    let tests = vec![
+        (vec!["-v"], "single verbose flag"),
+        (vec!["-vv"], "double verbose flag"),
+        (vec!["-vvv"], "triple verbose flag"),
+        (vec!["--verbose"], "long verbose flag"),
+        (
+            vec!["--verbose", "--verbose"],
+            "multiple long verbose flags",
+        ),
+    ];
+
+    for (verbose_args, desc) in tests {
+        let mut args = vec!["run", "--bin", "cribo", "--"];
+        args.extend(verbose_args);
+        args.extend(&["--entry", "nonexistent.py", "--output", "out.py"]);
+
+        let output = Command::new("cargo")
+            .args(args)
+            .output()
+            .expect("Failed to execute command");
+
+        // The command should fail because the entry file doesn't exist,
+        // but it should parse the verbose flags without error
+        assert!(!output.status.success(), "Expected failure for {}", desc);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Should not have parsing errors
+        assert!(
+            !stderr.contains("error: invalid value"),
+            "Failed to parse {}",
+            desc
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Implement verbose flag that can be repeated to increase logging verbosity
- Map verbose levels to appropriate RUST_LOG levels for debugging
- Add comprehensive documentation and tests

## Changes

This PR adds support for repeating the verbose flag (`-v`) to increase logging verbosity progressively:

- **No flag**: warnings and errors only (warn level)
- **`-v`**: informational messages (info level)  
- **`-vv`**: debug messages (debug level)
- **`-vvv` or more**: trace messages (trace level)

### Implementation Details

- Changed the CLI argument from a boolean to a count using `clap::ArgAction::Count`
- Map the count to appropriate log levels in the logging initialization
- Add debug message showing the verbosity level for troubleshooting

### Testing

- Added `test_cli_verbose.rs` with tests for:
  - Help text validation
  - Multiple verbose flag parsing variations
  - Verified all combinations parse correctly

### Documentation

Updated all documentation to reflect the new verbose flag behavior:
- **README.md**: Added comprehensive CLI options section with examples
- **CLAUDE.md**: Updated CLI usage examples for debugging
- **AGENTS.md**: Added CLI usage section with verbose flag details

## Test Plan

- [x] Run tests: `cargo test test_cli_verbose`
- [x] Verify help text: `cargo run --bin cribo -- --help`
- [x] Test verbose levels manually
- [x] All existing tests pass
- [x] Clippy shows no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)