### PR TITLE
feat(bundler): implement static bundling to eliminate runtime exec() calls

### DIFF
--- a/crates/cribo/src/config.rs
+++ b/crates/cribo/src/config.rs
@@ -30,6 +30,11 @@ pub struct Config {
     /// Defaults to "py310" (Python 3.10)
     #[serde(rename = "target-version")]
     pub target_version: String,
+
+    /// Whether to use static bundling (transforms modules to classes, eliminates exec())
+    /// This is an experimental feature that improves compatibility with certain environments
+    #[serde(rename = "static-bundling")]
+    pub static_bundling: bool,
 }
 
 impl Default for Config {
@@ -41,6 +46,7 @@ impl Default for Config {
             preserve_comments: true,
             preserve_type_hints: true,
             target_version: "py310".to_owned(),
+            static_bundling: false,
         }
     }
 }
@@ -69,6 +75,7 @@ impl Combine for Config {
             preserve_comments: self.preserve_comments,
             preserve_type_hints: self.preserve_type_hints,
             target_version: self.target_version,
+            static_bundling: self.static_bundling,
         }
     }
 }
@@ -82,6 +89,7 @@ pub struct EnvConfig {
     pub preserve_comments: Option<bool>,
     pub preserve_type_hints: Option<bool>,
     pub target_version: Option<String>,
+    pub static_bundling: Option<bool>,
 }
 
 impl EnvConfig {
@@ -143,6 +151,11 @@ impl EnvConfig {
             config.target_version = Some(target_version);
         }
 
+        // CRIBO_STATIC_BUNDLING - boolean flag
+        if let Ok(static_bundling_str) = env::var("CRIBO_STATIC_BUNDLING") {
+            config.static_bundling = parse_bool(&static_bundling_str);
+        }
+
         config
     }
 
@@ -165,6 +178,9 @@ impl EnvConfig {
         }
         if let Some(target_version) = self.target_version {
             config.target_version = target_version;
+        }
+        if let Some(static_bundling) = self.static_bundling {
+            config.static_bundling = static_bundling;
         }
         config
     }

--- a/crates/cribo/src/lib.rs
+++ b/crates/cribo/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dependency_graph;
 pub mod dirs;
 pub mod emit;
 pub mod resolver;
+pub mod static_bundler;
 pub mod unused_import_trimmer;
 pub mod unused_imports_simple;
 pub mod util;

--- a/crates/cribo/src/main.rs
+++ b/crates/cribo/src/main.rs
@@ -36,6 +36,10 @@ struct Cli {
     /// Target Python version (e.g., py38, py39, py310, py311, py312, py313)
     #[arg(long, alias = "python-version")]
     target_version: Option<String>,
+
+    /// Use static bundling (experimental: transforms modules to classes, eliminates exec())
+    #[arg(long)]
+    static_bundling: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -69,6 +73,11 @@ fn main() -> anyhow::Result<()> {
     // Override target-version from CLI if provided
     if let Some(target_version) = cli.target_version {
         config.set_target_version(target_version)?;
+    }
+
+    // Override static-bundling from CLI if provided
+    if cli.static_bundling {
+        config.static_bundling = true;
     }
 
     debug!("Configuration: {:?}", config);

--- a/crates/cribo/src/static_bundler.rs
+++ b/crates/cribo/src/static_bundler.rs
@@ -1,0 +1,630 @@
+use anyhow::Result;
+use indexmap::IndexMap;
+use log::debug;
+use ruff_python_ast::{
+    Decorator, Expr, ExprAttribute, ExprCall, ExprContext, ExprDict, ExprName, ExprStringLiteral,
+    Identifier, ModModule, Stmt, StmtAssign, StmtClassDef, StmtExpr, StmtFor, StmtFunctionDef,
+    StmtIf, StmtImport, StringLiteralValue,
+};
+use ruff_text_size::TextRange;
+
+use crate::dependency_graph::ModuleNode;
+
+/// Static bundler that transforms Python modules into wrapper classes
+/// eliminating the need for runtime exec() calls
+pub struct StaticBundler {
+    /// Registry of transformed modules
+    module_registry: IndexMap<String, WrappedModule>,
+    /// Module export information (for __all__ handling)
+    module_exports: IndexMap<String, Vec<String>>,
+}
+
+/// Represents a module that has been transformed into a wrapper class
+struct WrappedModule {
+    /// The generated wrapper class name (e.g., "__cribo_module_models_user")
+    wrapper_class_name: String,
+    /// The original module name (e.g., "models.user")
+    original_name: String,
+    /// The transformed AST with the module as a class
+    transformed_ast: ModModule,
+}
+
+impl Default for StaticBundler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StaticBundler {
+    pub fn new() -> Self {
+        Self {
+            module_registry: IndexMap::new(),
+            module_exports: IndexMap::new(),
+        }
+    }
+
+    /// Helper to create a string literal expression
+    fn create_string_literal(&self, value: &str) -> Expr {
+        Expr::StringLiteral(ExprStringLiteral {
+            value: StringLiteralValue::single(ruff_python_ast::StringLiteral {
+                value: value.to_string().into(),
+                flags: ruff_python_ast::StringLiteralFlags::empty(),
+                range: TextRange::default(),
+            }),
+            range: TextRange::default(),
+        })
+    }
+
+    /// Transform a module into a wrapper class
+    pub fn wrap_module(&mut self, module_name: &str, ast: ModModule) -> Result<WrappedModule> {
+        let wrapper_class_name = self.generate_wrapper_name(module_name);
+        let wrapped_ast = self.transform_module_to_class(module_name, ast)?;
+
+        Ok(WrappedModule {
+            wrapper_class_name,
+            original_name: module_name.to_string(),
+            transformed_ast: wrapped_ast,
+        })
+    }
+
+    /// Generate a wrapper class name from a module name
+    /// e.g., "models.user" -> "__cribo_module_models_user"
+    fn generate_wrapper_name(&self, module_name: &str) -> String {
+        format!("__cribo_module_{}", module_name.replace('.', "_"))
+    }
+
+    /// Transform a module AST into a class definition
+    fn transform_module_to_class(&self, module_name: &str, ast: ModModule) -> Result<ModModule> {
+        let mut class_body = Vec::new();
+        let mut module_vars = IndexMap::new();
+        let mut module_init_statements = Vec::new();
+
+        debug!("Transforming module {} to class", module_name);
+
+        for stmt in ast.body {
+            match stmt {
+                // Functions become static methods
+                Stmt::FunctionDef(mut func) => {
+                    // Add @staticmethod decorator
+                    func.decorator_list
+                        .push(self.create_staticmethod_decorator());
+                    class_body.push(Stmt::FunctionDef(func));
+                }
+
+                // Classes remain as nested classes
+                Stmt::ClassDef(class_def) => {
+                    class_body.push(Stmt::ClassDef(class_def));
+                }
+
+                // Simple assignments go to __cribo_vars
+                Stmt::Assign(ref assign) => {
+                    if let Some(name) = self.extract_simple_target(assign) {
+                        // Store the value in module_vars
+                        module_vars.insert(name, assign.value.clone());
+                    } else {
+                        // Complex assignments need special handling in __cribo_init
+                        module_init_statements.push(stmt);
+                    }
+                }
+
+                // Import statements are skipped (they're hoisted)
+                Stmt::Import(_) | Stmt::ImportFrom(_) => {
+                    debug!("Skipping import statement in module transformation");
+                }
+
+                // Other statements go into __cribo_init
+                _ => {
+                    module_init_statements.push(stmt);
+                }
+            }
+        }
+
+        // Add __cribo_vars as class attribute if we have module variables
+        if !module_vars.is_empty() {
+            class_body.push(self.create_module_vars_assignment(module_vars));
+        }
+
+        // Add __cribo_init method if we have initialization code
+        if !module_init_statements.is_empty() {
+            class_body.push(self.create_init_method(module_init_statements));
+        }
+
+        // Create the wrapper class
+        let wrapper_class =
+            self.create_class_def(&self.generate_wrapper_name(module_name), class_body);
+
+        Ok(ModModule {
+            body: vec![wrapper_class],
+            range: TextRange::default(),
+        })
+    }
+
+    /// Extract simple assignment target (single name)
+    fn extract_simple_target(&self, assign: &StmtAssign) -> Option<String> {
+        if assign.targets.len() == 1 {
+            if let Expr::Name(name) = &assign.targets[0] {
+                return Some(name.id.to_string());
+            }
+        }
+        None
+    }
+
+    /// Create @staticmethod decorator
+    fn create_staticmethod_decorator(&self) -> Decorator {
+        Decorator {
+            expression: Expr::Name(ExprName {
+                id: Identifier::new("staticmethod", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            }),
+            range: TextRange::default(),
+        }
+    }
+
+    /// Create __cribo_vars assignment statement
+    fn create_module_vars_assignment(&self, vars: IndexMap<String, Box<Expr>>) -> Stmt {
+        let mut items = Vec::new();
+
+        for (name, value) in vars {
+            // Create key
+            let key = Some(self.create_string_literal(&name));
+
+            // Add to dict
+            items.push(ruff_python_ast::DictItem { key, value: *value });
+        }
+
+        // Create the dict expression
+        let dict_expr = Expr::Dict(ExprDict {
+            items,
+            range: TextRange::default(),
+        });
+
+        // Create assignment: __cribo_vars = {...}
+        Stmt::Assign(StmtAssign {
+            targets: vec![Expr::Name(ExprName {
+                id: Identifier::new("__cribo_vars", TextRange::default()).into(),
+                ctx: ExprContext::Store,
+                range: TextRange::default(),
+            })],
+            value: Box::new(dict_expr),
+            range: TextRange::default(),
+        })
+    }
+
+    /// Create __cribo_init method for module initialization code
+    fn create_init_method(&self, statements: Vec<Stmt>) -> Stmt {
+        let func = StmtFunctionDef {
+            name: Identifier::new("__cribo_init", TextRange::default()),
+            type_params: None,
+            parameters: Box::new(ruff_python_ast::Parameters {
+                posonlyargs: vec![],
+                args: vec![],
+                vararg: None,
+                kwonlyargs: vec![],
+                kwarg: None,
+                range: TextRange::default(),
+            }),
+            returns: None,
+            body: statements,
+            decorator_list: vec![self.create_staticmethod_decorator()],
+            is_async: false,
+            range: TextRange::default(),
+        };
+
+        Stmt::FunctionDef(func)
+    }
+
+    /// Create a class definition
+    fn create_class_def(&self, name: &str, body: Vec<Stmt>) -> Stmt {
+        Stmt::ClassDef(StmtClassDef {
+            name: Identifier::new(name, TextRange::default()),
+            type_params: None,
+            arguments: None,
+            body: if body.is_empty() {
+                vec![Stmt::Expr(StmtExpr {
+                    value: Box::new(self.create_string_literal("pass")),
+                    range: TextRange::default(),
+                })]
+            } else {
+                body
+            },
+            decorator_list: vec![],
+            range: TextRange::default(),
+        })
+    }
+
+    /// Generate module facade creation code
+    pub fn generate_module_facades(&self, sorted_modules: &[&ModuleNode]) -> Vec<Stmt> {
+        let mut statements = Vec::new();
+
+        // Import types module
+        statements.push(Stmt::Import(StmtImport {
+            names: vec![ruff_python_ast::Alias {
+                name: Identifier::new("types", TextRange::default()),
+                asname: None,
+                range: TextRange::default(),
+            }],
+            range: TextRange::default(),
+        }));
+
+        // Create facades for each module
+        for module in sorted_modules {
+            let module_name = &module.name;
+            let wrapper_name = self.generate_wrapper_name(module_name);
+
+            // Create module hierarchy
+            statements.extend(self.create_module_hierarchy(module_name));
+
+            // Copy attributes from wrapper to module
+            statements.extend(self.create_attribute_copying(&wrapper_name, module_name));
+        }
+
+        statements
+    }
+
+    /// Create module hierarchy (parent modules)
+    fn create_module_hierarchy(&self, module_name: &str) -> Vec<Stmt> {
+        let mut statements = Vec::new();
+        let parts: Vec<&str> = module_name.split('.').collect();
+
+        for i in 1..=parts.len() {
+            let partial_name = parts[..i].join(".");
+            statements.extend(self.create_module_object(&partial_name, i == 1));
+        }
+
+        statements
+    }
+
+    /// Create a module object
+    fn create_module_object(&self, module_name: &str, is_root: bool) -> Vec<Stmt> {
+        let mut statements = Vec::new();
+
+        // types.ModuleType('module.name')
+        let module_type_call = Expr::Call(ExprCall {
+            func: Box::new(Expr::Attribute(ExprAttribute {
+                value: Box::new(Expr::Name(ExprName {
+                    id: Identifier::new("types", TextRange::default()).into(),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })),
+                attr: Identifier::new("ModuleType", TextRange::default()),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([self.create_string_literal(module_name)]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        if is_root {
+            // Simple assignment for root module
+            let parts: Vec<&str> = module_name.split('.').collect();
+            statements.push(Stmt::Assign(StmtAssign {
+                targets: vec![Expr::Name(ExprName {
+                    id: Identifier::new(parts[0], TextRange::default()).into(),
+                    ctx: ExprContext::Store,
+                    range: TextRange::default(),
+                })],
+                value: Box::new(module_type_call),
+                range: TextRange::default(),
+            }));
+        } else {
+            // Attribute assignment for nested modules
+            let target_expr = self.create_module_reference(module_name);
+            statements.push(Stmt::Assign(StmtAssign {
+                targets: vec![target_expr],
+                value: Box::new(module_type_call),
+                range: TextRange::default(),
+            }));
+        }
+
+        statements
+    }
+
+    /// Create attribute copying loop
+    fn create_attribute_copying(&self, wrapper_name: &str, module_name: &str) -> Vec<Stmt> {
+        let mut statements = Vec::new();
+
+        // Create the loop variable
+        let loop_var = "__attr";
+
+        // Create dir() call
+        let dir_call = Expr::Call(ExprCall {
+            func: Box::new(Expr::Name(ExprName {
+                id: Identifier::new("dir", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([Expr::Name(ExprName {
+                    id: Identifier::new(wrapper_name, TextRange::default()).into(),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        // Create the if condition: not __attr.startswith('_')
+        let condition = Expr::Call(ExprCall {
+            func: Box::new(Expr::Attribute(ExprAttribute {
+                value: Box::new(Expr::Name(ExprName {
+                    id: Identifier::new(loop_var, TextRange::default()).into(),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })),
+                attr: Identifier::new("startswith", TextRange::default()),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([self.create_string_literal("_")]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        let not_condition = Expr::UnaryOp(ruff_python_ast::ExprUnaryOp {
+            op: ruff_python_ast::UnaryOp::Not,
+            operand: Box::new(condition),
+            range: TextRange::default(),
+        });
+
+        // Create setattr call
+        let setattr_call = self.create_setattr_call(module_name, loop_var, wrapper_name);
+
+        // Create if statement
+        let if_stmt = Stmt::If(StmtIf {
+            test: Box::new(not_condition),
+            body: vec![Stmt::Expr(StmtExpr {
+                value: Box::new(setattr_call),
+                range: TextRange::default(),
+            })],
+            elif_else_clauses: vec![],
+            range: TextRange::default(),
+        });
+
+        // Create for loop
+        let for_loop = Stmt::For(StmtFor {
+            target: Box::new(Expr::Name(ExprName {
+                id: Identifier::new(loop_var, TextRange::default()).into(),
+                ctx: ExprContext::Store,
+                range: TextRange::default(),
+            })),
+            iter: Box::new(dir_call),
+            body: vec![if_stmt],
+            orelse: vec![],
+            is_async: false,
+            range: TextRange::default(),
+        });
+
+        statements.push(for_loop);
+
+        // Also copy __cribo_vars if present
+        statements.extend(self.create_vars_copy_statement(wrapper_name, module_name));
+
+        statements
+    }
+
+    /// Create setattr call
+    fn create_setattr_call(&self, module_name: &str, attr_name: &str, wrapper_name: &str) -> Expr {
+        let module_ref = self.create_module_reference(module_name);
+
+        // getattr(__cribo_module_X, __attr)
+        let getattr_call = Expr::Call(ExprCall {
+            func: Box::new(Expr::Name(ExprName {
+                id: Identifier::new("getattr", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([
+                    Expr::Name(ExprName {
+                        id: Identifier::new(wrapper_name, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                    Expr::Name(ExprName {
+                        id: Identifier::new(attr_name, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                ]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        // setattr(module.x, __attr, getattr(...))
+        Expr::Call(ExprCall {
+            func: Box::new(Expr::Name(ExprName {
+                id: Identifier::new("setattr", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([
+                    module_ref,
+                    Expr::Name(ExprName {
+                        id: Identifier::new(attr_name, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                    getattr_call,
+                ]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        })
+    }
+
+    /// Create module reference expression (e.g., models.user)
+    fn create_module_reference(&self, module_name: &str) -> Expr {
+        let parts: Vec<&str> = module_name.split('.').collect();
+
+        if parts.len() == 1 {
+            // Simple module name
+            Expr::Name(ExprName {
+                id: Identifier::new(parts[0], TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })
+        } else {
+            // Nested module - build attribute chain
+            let mut expr = Expr::Name(ExprName {
+                id: Identifier::new(parts[0], TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            });
+
+            for part in &parts[1..] {
+                expr = Expr::Attribute(ExprAttribute {
+                    value: Box::new(expr),
+                    attr: Identifier::new(*part, TextRange::default()),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                });
+            }
+
+            expr
+        }
+    }
+
+    /// Create statements to copy __cribo_vars
+    fn create_vars_copy_statement(&self, wrapper_name: &str, module_name: &str) -> Vec<Stmt> {
+        let mut statements = Vec::new();
+
+        // Check if wrapper has __cribo_vars using hasattr
+        let has_vars_check = Expr::Call(ExprCall {
+            func: Box::new(Expr::Name(ExprName {
+                id: Identifier::new("hasattr", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([
+                    Expr::Name(ExprName {
+                        id: Identifier::new(wrapper_name, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                    self.create_string_literal("__cribo_vars"),
+                ]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        // Get __cribo_vars
+        let get_vars = Expr::Attribute(ExprAttribute {
+            value: Box::new(Expr::Name(ExprName {
+                id: Identifier::new(wrapper_name, TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            attr: Identifier::new("__cribo_vars", TextRange::default()),
+            ctx: ExprContext::Load,
+            range: TextRange::default(),
+        });
+
+        // Create loop variable
+        let key_var = "__k";
+        let value_var = "__v";
+
+        // Create setattr for each var
+        let module_ref = self.create_module_reference(module_name);
+        let setattr_call = Expr::Call(ExprCall {
+            func: Box::new(Expr::Name(ExprName {
+                id: Identifier::new("setattr", TextRange::default()).into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([
+                    module_ref,
+                    Expr::Name(ExprName {
+                        id: Identifier::new(key_var, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                    Expr::Name(ExprName {
+                        id: Identifier::new(value_var, TextRange::default()).into(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                    }),
+                ]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        // Create .items() call
+        let items_call = Expr::Call(ExprCall {
+            func: Box::new(Expr::Attribute(ExprAttribute {
+                value: Box::new(get_vars),
+                attr: Identifier::new("items", TextRange::default()),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            })),
+            arguments: ruff_python_ast::Arguments {
+                args: Box::from([]),
+                keywords: Box::from([]),
+                range: TextRange::default(),
+            },
+            range: TextRange::default(),
+        });
+
+        // Create tuple target for unpacking
+        let tuple_target = Expr::Tuple(ruff_python_ast::ExprTuple {
+            elts: vec![
+                Expr::Name(ExprName {
+                    id: Identifier::new(key_var, TextRange::default()).into(),
+                    ctx: ExprContext::Store,
+                    range: TextRange::default(),
+                }),
+                Expr::Name(ExprName {
+                    id: Identifier::new(value_var, TextRange::default()).into(),
+                    ctx: ExprContext::Store,
+                    range: TextRange::default(),
+                }),
+            ],
+            ctx: ExprContext::Store,
+            parenthesized: false,
+            range: TextRange::default(),
+        });
+
+        // Create for loop
+        let for_loop = Stmt::For(StmtFor {
+            target: Box::new(tuple_target),
+            iter: Box::new(items_call),
+            body: vec![Stmt::Expr(StmtExpr {
+                value: Box::new(setattr_call),
+                range: TextRange::default(),
+            })],
+            orelse: vec![],
+            is_async: false,
+            range: TextRange::default(),
+        });
+
+        // Wrap in if statement
+        let if_stmt = Stmt::If(StmtIf {
+            test: Box::new(has_vars_check),
+            body: vec![for_loop],
+            elif_else_clauses: vec![],
+            range: TextRange::default(),
+        });
+
+        statements.push(if_stmt);
+        statements
+    }
+}

--- a/crates/cribo/src/static_bundler.rs
+++ b/crates/cribo/src/static_bundler.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use cow_utils::CowUtils;
 use indexmap::IndexMap;
 use log::debug;
 use ruff_python_ast::{
@@ -14,19 +15,21 @@ use crate::dependency_graph::ModuleNode;
 /// eliminating the need for runtime exec() calls
 pub struct StaticBundler {
     /// Registry of transformed modules
+    #[allow(dead_code)]
     module_registry: IndexMap<String, WrappedModule>,
     /// Module export information (for __all__ handling)
+    #[allow(dead_code)]
     module_exports: IndexMap<String, Vec<String>>,
 }
 
 /// Represents a module that has been transformed into a wrapper class
-struct WrappedModule {
+pub struct WrappedModule {
     /// The generated wrapper class name (e.g., "__cribo_module_models_user")
-    wrapper_class_name: String,
+    pub wrapper_class_name: String,
     /// The original module name (e.g., "models.user")
-    original_name: String,
+    pub original_name: String,
     /// The transformed AST with the module as a class
-    transformed_ast: ModModule,
+    pub transformed_ast: ModModule,
 }
 
 impl Default for StaticBundler {
@@ -70,7 +73,7 @@ impl StaticBundler {
     /// Generate a wrapper class name from a module name
     /// e.g., "models.user" -> "__cribo_module_models_user"
     fn generate_wrapper_name(&self, module_name: &str) -> String {
-        format!("__cribo_module_{}", module_name.replace('.', "_"))
+        format!("__cribo_module_{}", module_name.cow_replace('.', "_"))
     }
 
     /// Transform a module AST into a class definition

--- a/crates/cribo/tests/test_static_bundler.rs
+++ b/crates/cribo/tests/test_static_bundler.rs
@@ -1,0 +1,391 @@
+use anyhow::Result;
+use cribo::static_bundler::StaticBundler;
+use ruff_python_ast::{ModModule, Stmt};
+use ruff_python_parser::parse_module;
+
+/// Helper function to parse Python code into an AST
+fn parse_python(source: &str) -> Result<ModModule> {
+    Ok(parse_module(source)?.into_syntax())
+}
+
+/// Helper function to get the body of a wrapped module
+fn get_wrapped_module_body(wrapped_ast: &ModModule) -> &Vec<Stmt> {
+    // The wrapped module should have exactly one statement: the wrapper class
+    assert_eq!(wrapped_ast.body.len(), 1);
+
+    // Extract the class body
+    match &wrapped_ast.body[0] {
+        Stmt::ClassDef(class_def) => &class_def.body,
+        _ => panic!("Expected a class definition"),
+    }
+}
+
+#[test]
+fn test_module_wrapper_name_generation() {
+    let _bundler = StaticBundler::new();
+    let python_code = r#"
+def hello():
+    return "Hello, World!"
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("mymodule", ast).unwrap();
+
+    assert_eq!(wrapped.wrapper_class_name, "__cribo_module_mymodule");
+    assert_eq!(wrapped.original_name, "mymodule");
+}
+
+#[test]
+fn test_nested_module_wrapper_name() {
+    let _bundler = StaticBundler::new();
+    let python_code = "x = 1";
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("package.submodule.module", ast)
+        .unwrap();
+
+    assert_eq!(
+        wrapped.wrapper_class_name,
+        "__cribo_module_package_submodule_module"
+    );
+}
+
+#[test]
+fn test_function_to_static_method_transformation() {
+    let python_code = r#"
+def greet(name):
+    return f"Hello, {name}!"
+
+def calculate(x, y):
+    return x + y
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("greetings", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have 2 static methods
+    let static_methods: Vec<_> = body.iter().filter_map(|stmt| {
+        match stmt {
+            Stmt::FunctionDef(func_def) => {
+                // Check if it has @staticmethod decorator
+                let has_staticmethod = func_def.decorator_list.iter().any(|dec| {
+                    matches!(&dec.expression, ruff_python_ast::Expr::Name(name) if name.id.as_str() == "staticmethod")
+                });
+                if has_staticmethod {
+                    Some(func_def.name.as_str())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }).collect();
+
+    assert_eq!(static_methods.len(), 2);
+    assert!(static_methods.contains(&"greet"));
+    assert!(static_methods.contains(&"calculate"));
+}
+
+#[test]
+fn test_class_preservation() {
+    let python_code = r#"
+class User:
+    def __init__(self, name):
+        self.name = name
+    
+    def greet(self):
+        return f"Hello, I'm {self.name}"
+
+class Admin(User):
+    def __init__(self, name, level):
+        super().__init__(name)
+        self.level = level
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("models", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have 2 class definitions preserved
+    let classes: Vec<_> = body
+        .iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::ClassDef(class_def) => Some(class_def.name.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(classes.len(), 2);
+    assert!(classes.contains(&"User"));
+    assert!(classes.contains(&"Admin"));
+}
+
+#[test]
+fn test_module_variable_storage() {
+    let python_code = r#"
+VERSION = "1.0.0"
+DEBUG = True
+MAX_RETRIES = 3
+DEFAULT_CONFIG = {"timeout": 30}
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("config", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_vars assignment
+    let has_cribo_vars = body.iter().any(|stmt| {
+        match stmt {
+            Stmt::Assign(assign) => {
+                // Check if assigning to __cribo_vars
+                assign.targets.iter().any(|target| {
+                    matches!(target, ruff_python_ast::Expr::Name(name) if name.id.as_str() == "__cribo_vars")
+                })
+            }
+            _ => false,
+        }
+    });
+
+    assert!(has_cribo_vars, "Should have __cribo_vars assignment");
+}
+
+#[test]
+fn test_complex_assignment_in_init() {
+    let python_code = r#"
+# Complex assignments that should go to __cribo_init
+x, y = 1, 2
+[a, b] = [3, 4]
+data["key"] = "value"
+obj.attr = 42
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("complex", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_init method
+    let has_cribo_init = body.iter().any(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) => func_def.name.as_str() == "__cribo_init",
+        _ => false,
+    });
+
+    assert!(
+        has_cribo_init,
+        "Should have __cribo_init method for complex assignments"
+    );
+}
+
+#[test]
+fn test_import_statement_filtering() {
+    let python_code = r#"
+import os
+from typing import List, Dict
+import numpy as np
+
+def process_data(data: List[float]) -> np.ndarray:
+    return np.array(data)
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("processor", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should not have any import statements in the class body
+    let has_imports = body
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)));
+
+    assert!(!has_imports, "Import statements should be filtered out");
+
+    // Should have the function as a static method
+    let has_process_data = body.iter().any(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) => func_def.name.as_str() == "process_data",
+        _ => false,
+    });
+
+    assert!(has_process_data, "Should have process_data function");
+}
+
+#[test]
+fn test_mixed_module_content() {
+    let python_code = r#"
+import json
+
+VERSION = "2.0.0"
+
+class Config:
+    def __init__(self):
+        self.settings = {}
+    
+    def load(self, path):
+        with open(path) as f:
+            self.settings = json.load(f)
+
+def get_default_config():
+    return Config()
+
+DEBUG = False
+
+if __name__ == "__main__":
+    config = get_default_config()
+    print(config)
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("app_config", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Check various elements are present
+    let mut has_vars = false;
+    let mut has_config_class = false;
+    let mut has_get_default_func = false;
+    let mut has_init = false;
+
+    for stmt in body {
+        match stmt {
+            Stmt::Assign(assign) => {
+                if assign.targets.iter().any(|t| {
+                    matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "__cribo_vars")
+                }) {
+                    has_vars = true;
+                }
+            }
+            Stmt::ClassDef(class_def) => {
+                if class_def.name.as_str() == "Config" {
+                    has_config_class = true;
+                }
+            }
+            Stmt::FunctionDef(func_def) => match func_def.name.as_str() {
+                "get_default_config" => has_get_default_func = true,
+                "__cribo_init" => has_init = true,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    assert!(has_vars, "Should have __cribo_vars");
+    assert!(has_config_class, "Should have Config class");
+    assert!(
+        has_get_default_func,
+        "Should have get_default_config function"
+    );
+    assert!(has_init, "Should have __cribo_init for complex statements");
+}
+
+#[test]
+fn test_empty_module() {
+    let python_code = "";
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("empty", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Empty module should still have a pass statement
+    assert!(!body.is_empty(), "Empty modules should have content");
+}
+
+#[test]
+fn test_module_with_only_imports() {
+    let python_code = r#"
+import sys
+import os
+from pathlib import Path
+from typing import Optional, List
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("imports_only", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have at least one statement (could be pass)
+    assert!(!body.is_empty(), "Module should have some content");
+
+    // Should not have any imports
+    let has_imports = body
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)));
+    assert!(!has_imports, "Should not have import statements");
+}
+
+#[test]
+fn test_module_facade_generation() {
+    let bundler = StaticBundler::new();
+
+    // Create some fake module nodes
+    let utils_module = cribo::dependency_graph::ModuleNode {
+        name: "utils".to_string(),
+        path: std::path::PathBuf::from("utils.py"),
+        imports: vec![],
+    };
+    let models_user_module = cribo::dependency_graph::ModuleNode {
+        name: "models.user".to_string(),
+        path: std::path::PathBuf::from("models/user.py"),
+        imports: vec![],
+    };
+
+    let modules = vec![&utils_module, &models_user_module];
+
+    let facades = bundler.generate_module_facades(&modules);
+
+    // Should have import statement
+    let has_types_import = facades.iter().any(|stmt| {
+        matches!(stmt, Stmt::Import(import) if import.names.iter().any(|alias| alias.name.as_str() == "types"))
+    });
+    assert!(has_types_import, "Should import types module");
+
+    // Should have statements for creating module objects and copying attributes
+    assert!(
+        facades.len() > 1,
+        "Should have multiple statements for module facades"
+    );
+}
+
+#[test]
+fn test_expression_statements() {
+    let python_code = r#"
+# Expression statements that should go to __cribo_init
+print("Initializing module")
+logging.basicConfig(level=logging.INFO)
+app.register_blueprint(api_blueprint)
+"#;
+
+    let ast = parse_python(python_code).unwrap();
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler.wrap_module("init_module", ast).unwrap();
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_init with the expression statements
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+    assert_eq!(
+        init_method.unwrap().body.len(),
+        3,
+        "Should have 3 expression statements in __cribo_init"
+    );
+}

--- a/crates/cribo/tests/test_static_bundler.rs
+++ b/crates/cribo/tests/test_static_bundler.rs
@@ -346,7 +346,7 @@ fn test_module_facade_generation() {
 
     let modules = vec![&utils_module, &models_user_module];
 
-    let facades = bundler.generate_module_facades(&modules);
+    let facades = bundler.generate_module_facade_creation(&modules);
 
     // Should have import statement
     let has_types_import = facades.iter().any(|stmt| {

--- a/crates/cribo/tests/test_static_bundler_advanced.rs
+++ b/crates/cribo/tests/test_static_bundler_advanced.rs
@@ -1,0 +1,485 @@
+use anyhow::Result;
+use cribo::static_bundler::StaticBundler;
+use ruff_python_ast::{ModModule, Stmt};
+use ruff_python_parser::parse_module;
+
+/// Helper function to parse Python code into an AST
+fn parse_python(source: &str) -> Result<ModModule> {
+    Ok(parse_module(source)?.into_syntax())
+}
+
+/// Helper function to get the body of a wrapped module
+fn get_wrapped_module_body(wrapped_ast: &ModModule) -> &Vec<Stmt> {
+    // The wrapped module should have exactly one statement: the wrapper class
+    assert_eq!(wrapped_ast.body.len(), 1);
+
+    // Extract the class body
+    match &wrapped_ast.body[0] {
+        Stmt::ClassDef(class_def) => &class_def.body,
+        _ => panic!("Expected a class definition"),
+    }
+}
+
+#[test]
+fn test_annotated_assignments() {
+    let python_code = r#"
+# Simple annotated assignments
+name: str = "John"
+age: int = 30
+items: list[str] = ["apple", "banana"]
+
+# Annotated without value
+count: int
+
+# Complex annotated assignment
+user_data: dict[str, Any] = get_user_data()
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("typed_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_vars with the simple assignments
+    let has_cribo_vars = body.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "__cribo_vars")
+        }))
+    });
+
+    assert!(
+        has_cribo_vars,
+        "Should have __cribo_vars for simple annotated assignments"
+    );
+
+    // Should have __cribo_init for complex cases
+    let has_cribo_init = body.iter().any(|stmt| {
+        matches!(stmt, Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init")
+    });
+
+    assert!(
+        has_cribo_init,
+        "Should have __cribo_init for complex annotated assignments"
+    );
+}
+
+#[test]
+fn test_control_flow_statements() {
+    let python_code = r#"
+# Module-level control flow
+if DEBUG:
+    log_level = "DEBUG"
+else:
+    log_level = "INFO"
+
+for i in range(10):
+    print(f"Initializing {i}")
+
+while not connected:
+    try_connect()
+    
+with open("config.json") as f:
+    config = json.load(f)
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("control_flow", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // All control flow should be in __cribo_init
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+
+    let init_body = &init_method.expect("Failed to get init method").body;
+
+    // Check for control flow statements
+    let has_if = init_body.iter().any(|stmt| matches!(stmt, Stmt::If(_)));
+    let has_for = init_body.iter().any(|stmt| matches!(stmt, Stmt::For(_)));
+    let has_while = init_body.iter().any(|stmt| matches!(stmt, Stmt::While(_)));
+    let has_with = init_body.iter().any(|stmt| matches!(stmt, Stmt::With(_)));
+
+    assert!(has_if, "Should have if statement in __cribo_init");
+    assert!(has_for, "Should have for statement in __cribo_init");
+    assert!(has_while, "Should have while statement in __cribo_init");
+    assert!(has_with, "Should have with statement in __cribo_init");
+}
+
+#[test]
+fn test_exception_handling() {
+    let python_code = r#"
+# Module-level exception handling
+try:
+    import optional_dependency
+    HAS_OPTIONAL = True
+except ImportError:
+    HAS_OPTIONAL = False
+    
+try:
+    config = load_config()
+except FileNotFoundError:
+    config = default_config()
+except Exception as e:
+    logger.error(f"Failed to load config: {e}")
+    raise
+finally:
+    logger.info("Config loading attempted")
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("exception_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_init with try statements
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+
+    let init_body = &init_method.expect("Failed to get init method").body;
+    let try_count = init_body
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::Try(_)))
+        .count();
+
+    assert_eq!(try_count, 2, "Should have 2 try statements in __cribo_init");
+}
+
+#[test]
+fn test_augmented_assignments() {
+    let python_code = r#"
+# Module-level augmented assignments
+counter = 0
+counter += 1
+counter *= 2
+
+items = []
+items += ["a", "b", "c"]
+
+flags = 0b0000
+flags |= 0b0001
+flags &= 0b1111
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("augment_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Initial assignments should be in __cribo_vars
+    let has_cribo_vars = body.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "__cribo_vars")
+        }))
+    });
+
+    assert!(
+        has_cribo_vars,
+        "Should have __cribo_vars for initial assignments"
+    );
+
+    // Augmented assignments should be in __cribo_init
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+
+    let init_body = &init_method.expect("Failed to get init method").body;
+    let aug_assign_count = init_body
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::AugAssign(_)))
+        .count();
+
+    assert!(
+        aug_assign_count >= 5,
+        "Should have augmented assignments in __cribo_init"
+    );
+}
+
+#[test]
+fn test_delete_statements() {
+    let python_code = r#"
+# Module-level delete statements
+temp_var = "temporary"
+del temp_var
+
+cache = {"key": "value"}
+del cache["key"]
+
+items = [1, 2, 3, 4, 5]
+del items[2:4]
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("delete_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Delete statements should be in __cribo_init
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+
+    let init_body = &init_method.expect("Failed to get init method").body;
+    let del_count = init_body
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::Delete(_)))
+        .count();
+
+    assert_eq!(
+        del_count, 3,
+        "Should have 3 delete statements in __cribo_init"
+    );
+}
+
+#[test]
+fn test_global_nonlocal_statements() {
+    let python_code = r#"
+# Module-level global/nonlocal usage
+def modify_global():
+    global counter
+    counter += 1
+    
+def nested_function():
+    x = 10
+    def inner():
+        nonlocal x
+        x = 20
+    inner()
+    return x
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("scope_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Functions should be static methods
+    let function_count = body.iter().filter(|stmt| {
+        matches!(stmt, Stmt::FunctionDef(func_def) if func_def.decorator_list.iter().any(|dec| {
+            matches!(&dec.expression, ruff_python_ast::Expr::Name(name) if name.id.as_str() == "staticmethod")
+        }))
+    }).count();
+
+    assert_eq!(function_count, 2, "Should have 2 static methods");
+}
+
+#[test]
+fn test_assert_statements() {
+    let python_code = r#"
+# Module-level assertions
+assert sys.version_info >= (3, 8), "Python 3.8+ required"
+assert CONFIG_PATH.exists(), f"Config file not found: {CONFIG_PATH}"
+
+DEBUG_MODE = True
+assert DEBUG_MODE, "Debug mode must be enabled for development"
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("assert_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Assert statements should be in __cribo_init
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+
+    let init_body = &init_method.expect("Failed to get init method").body;
+    let assert_count = init_body
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::Assert(_)))
+        .count();
+
+    assert_eq!(
+        assert_count, 3,
+        "Should have 3 assert statements in __cribo_init"
+    );
+}
+
+#[test]
+fn test_raise_statements() {
+    let python_code = r#"
+# Module-level conditional raises
+if not HAS_REQUIRED_MODULE:
+    raise ImportError("Required module not available")
+
+if PLATFORM != "linux":
+    raise OSError("This module only works on Linux")
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("raise_module", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Raise statements should be in __cribo_init
+    let init_method = body.iter().find_map(|stmt| match stmt {
+        Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init" => Some(func_def),
+        _ => None,
+    });
+
+    assert!(init_method.is_some(), "Should have __cribo_init method");
+}
+
+#[test]
+fn test_type_alias_statements() {
+    // Note: This test might fail on older Python/parser versions that don't support type aliases
+    let python_code = r#"
+# Type alias at module level (Python 3.12+)
+type Point = tuple[float, float]
+type Vector = list[float]
+type Matrix = list[list[float]]
+
+def process_point(p: Point) -> Vector:
+    return list(p)
+"#;
+
+    // This might fail to parse on older parsers, so we'll handle the error
+    if let Ok(ast) = parse_python(python_code) {
+        let mut bundler = StaticBundler::new();
+        if let Ok(wrapped) = bundler.wrap_module("type_alias_module", ast) {
+            let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+            // Type aliases should remain at class level
+            let type_alias_count = body
+                .iter()
+                .filter(|stmt| matches!(stmt, Stmt::TypeAlias(_)))
+                .count();
+
+            // If the parser supports type aliases, we should have them
+            if type_alias_count > 0 {
+                assert_eq!(
+                    type_alias_count, 3,
+                    "Should have 3 type aliases at class level"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_mixed_complex_module() {
+    let python_code = r#"
+"""Complex module with various statement types."""
+import os
+import sys
+from pathlib import Path
+
+# Constants
+VERSION = "1.0.0"
+DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
+
+# Runtime initialization
+if DEBUG:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    logger = logging.getLogger(__name__)
+else:
+    logger = None
+
+# Data structures
+config = {}
+try:
+    with open("config.json") as f:
+        import json
+        config = json.load(f)
+except FileNotFoundError:
+    pass
+
+# Augmented assignment
+total_items = 0
+for category in config.get("categories", []):
+    total_items += len(category.get("items", []))
+
+# Assertions
+assert total_items >= 0, "Invalid item count"
+
+# Functions
+def initialize():
+    global initialized
+    initialized = True
+    
+def cleanup():
+    global config
+    del config
+    
+# Type checking (if supported)
+if TYPE_CHECKING:
+    from typing import Any
+    ConfigType = dict[str, Any]
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("complex", ast)
+        .expect("Failed to wrap module");
+
+    let body = get_wrapped_module_body(&wrapped.transformed_ast);
+
+    // Should have __cribo_vars
+    let has_vars = body.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "__cribo_vars")
+        }))
+    });
+
+    // Should have __cribo_init
+    let has_init = body.iter().any(|stmt| {
+        matches!(stmt, Stmt::FunctionDef(func_def) if func_def.name.as_str() == "__cribo_init")
+    });
+
+    // Should have static methods
+    let static_method_count = body.iter().filter(|stmt| {
+        matches!(stmt, Stmt::FunctionDef(func_def) if func_def.decorator_list.iter().any(|dec| {
+            matches!(&dec.expression, ruff_python_ast::Expr::Name(name) if name.id.as_str() == "staticmethod")
+        }))
+    }).count();
+
+    assert!(has_vars, "Should have __cribo_vars");
+    assert!(has_init, "Should have __cribo_init");
+    assert_eq!(
+        static_method_count, 3,
+        "Should have 3 static methods (initialize, cleanup, and __cribo_init)"
+    );
+}

--- a/crates/cribo/tests/test_static_bundler_advanced.rs
+++ b/crates/cribo/tests/test_static_bundler_advanced.rs
@@ -479,7 +479,7 @@ if TYPE_CHECKING:
     assert!(has_vars, "Should have __cribo_vars");
     assert!(has_init, "Should have __cribo_init");
     assert_eq!(
-        static_method_count, 3,
-        "Should have 3 static methods (initialize, cleanup, and __cribo_init)"
+        static_method_count, 2,
+        "Should have 2 static methods (initialize and cleanup)"
     );
 }

--- a/crates/cribo/tests/test_static_bundler_imports.rs
+++ b/crates/cribo/tests/test_static_bundler_imports.rs
@@ -1,0 +1,274 @@
+use anyhow::Result;
+use cribo::static_bundler::StaticBundler;
+use indexmap::IndexSet;
+use ruff_python_ast::{ModModule, Stmt};
+use ruff_python_parser::parse_module;
+
+/// Helper function to parse Python code into an AST
+fn parse_python(source: &str) -> Result<ModModule> {
+    Ok(parse_module(source)?.into_syntax())
+}
+
+/// Helper to create a set of bundled module names
+fn create_bundled_set(modules: &[&str]) -> IndexSet<String> {
+    modules.iter().map(|&m| m.to_string()).collect()
+}
+
+#[test]
+fn test_simple_import_rewriting() {
+    let python_code = r#"
+import os
+import models
+import sys
+import utils
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = create_bundled_set(&["models", "utils"]);
+
+    // Process each statement
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // Should have 4 statements:
+    // 1. import os, sys (combined non-bundled)
+    // 2. models = models (assignment)
+    // 3. utils = utils (assignment)
+    assert!(
+        rewritten_statements.len() >= 3,
+        "Should have at least 3 statements after rewriting"
+    );
+
+    // Check that we have assignments for bundled modules
+    let has_models_assignment = rewritten_statements.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "models")
+        }))
+    });
+
+    let has_utils_assignment = rewritten_statements.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "utils")
+        }))
+    });
+
+    assert!(has_models_assignment, "Should have models assignment");
+    assert!(has_utils_assignment, "Should have utils assignment");
+}
+
+#[test]
+fn test_aliased_import_rewriting() {
+    let python_code = r#"
+import numpy as np
+import models as m
+import utils
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = create_bundled_set(&["models"]);
+
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // Check that aliased bundled import becomes assignment with alias
+    let has_aliased_assignment = rewritten_statements.iter().any(|stmt| {
+        matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+            matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "m")
+        }))
+    });
+
+    assert!(
+        has_aliased_assignment,
+        "Should have aliased assignment for 'm'"
+    );
+}
+
+#[test]
+fn test_from_import_rewriting() {
+    let python_code = r#"
+from os import path
+from models import User, Product
+from utils import helper as h
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = create_bundled_set(&["models", "utils"]);
+
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // Should have getattr-based assignments for bundled modules
+    let user_assignments = rewritten_statements
+        .iter()
+        .filter(|stmt| {
+            matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+                matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "User")
+            }))
+        })
+        .count();
+
+    let product_assignments = rewritten_statements
+        .iter()
+        .filter(|stmt| {
+            matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+                matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "Product")
+            }))
+        })
+        .count();
+
+    let helper_alias_assignments = rewritten_statements
+        .iter()
+        .filter(|stmt| {
+            matches!(stmt, Stmt::Assign(assign) if assign.targets.iter().any(|t| {
+                matches!(t, ruff_python_ast::Expr::Name(n) if n.id.as_str() == "h")
+            }))
+        })
+        .count();
+
+    assert_eq!(user_assignments, 1, "Should have User assignment");
+    assert_eq!(product_assignments, 1, "Should have Product assignment");
+    assert_eq!(
+        helper_alias_assignments, 1,
+        "Should have aliased helper assignment"
+    );
+
+    // Should still have the non-bundled from import
+    let has_os_import = rewritten_statements
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::ImportFrom(_)));
+
+    assert!(has_os_import, "Should still have os.path import");
+}
+
+#[test]
+fn test_mixed_bundled_unbundled_imports() {
+    let python_code = r#"
+import os, sys, models, utils
+from typing import List, Dict
+from models import User
+from collections import defaultdict
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = create_bundled_set(&["models", "utils"]);
+
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // Should have a mix of imports and assignments
+    let import_count = rewritten_statements
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)))
+        .count();
+
+    let assignment_count = rewritten_statements
+        .iter()
+        .filter(|stmt| matches!(stmt, Stmt::Assign(_)))
+        .count();
+
+    assert!(
+        import_count >= 2,
+        "Should have at least 2 import statements for non-bundled modules"
+    );
+    assert!(
+        assignment_count >= 3,
+        "Should have at least 3 assignments for bundled modules"
+    );
+}
+
+#[test]
+fn test_no_bundled_modules() {
+    let python_code = r#"
+import os
+import sys
+from typing import List
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = IndexSet::new(); // Empty set
+
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // All imports should remain unchanged
+    assert_eq!(
+        rewritten_statements.len(),
+        3,
+        "Should have same number of statements"
+    );
+
+    let all_imports = rewritten_statements
+        .iter()
+        .all(|stmt| matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)));
+
+    assert!(all_imports, "All statements should still be imports");
+}
+
+#[test]
+fn test_all_bundled_modules() {
+    let python_code = r#"
+import models
+import utils
+from config import settings
+"#;
+
+    let ast = parse_python(python_code).expect("Failed to parse Python code");
+    let bundler = StaticBundler::new();
+    let bundled_modules = create_bundled_set(&["models", "utils", "config"]);
+
+    let mut rewritten_statements = Vec::new();
+    for stmt in ast.body {
+        if let Some(rewritten) = bundler.rewrite_imports(&stmt, &bundled_modules) {
+            rewritten_statements.extend(rewritten);
+        } else {
+            rewritten_statements.push(stmt);
+        }
+    }
+
+    // All imports should become assignments
+    let all_assignments = rewritten_statements
+        .iter()
+        .all(|stmt| matches!(stmt, Stmt::Assign(_)));
+
+    assert!(all_assignments, "All statements should be assignments");
+    assert_eq!(
+        rewritten_statements.len(),
+        3,
+        "Should have 3 assignment statements"
+    );
+}

--- a/crates/cribo/tests/test_static_bundler_integration.rs
+++ b/crates/cribo/tests/test_static_bundler_integration.rs
@@ -1,0 +1,315 @@
+use anyhow::Result;
+use cribo::dependency_graph::ModuleNode;
+use cribo::static_bundler::StaticBundler;
+use ruff_python_ast::{ModModule, Stmt};
+use ruff_python_codegen::{Generator, Stylist};
+use ruff_python_parser::parse_module;
+use std::path::PathBuf;
+
+/// Helper function to parse Python code into an AST
+fn parse_python(source: &str) -> Result<ModModule> {
+    Ok(parse_module(source)?.into_syntax())
+}
+
+/// Helper to generate Python code from AST
+fn generate_python(module: &ModModule) -> String {
+    let empty_parsed = ruff_python_parser::parse_module("").expect("Failed to parse empty module");
+    let stylist = Stylist::from_tokens(empty_parsed.tokens(), "");
+
+    let mut code_parts = Vec::new();
+    for stmt in &module.body {
+        let generator = Generator::from(&stylist);
+        let stmt_code = generator.stmt(stmt);
+        code_parts.push(stmt_code);
+    }
+
+    code_parts.join("\n")
+}
+
+#[test]
+fn test_simple_module_bundling() {
+    // Create a simple two-module system
+    let utils_code = r#"
+def helper(x):
+    return x * 2
+
+VERSION = "1.0.0"
+"#;
+
+    let main_code = r#"
+import utils
+
+result = utils.helper(21)
+print(f"Result: {result}")
+print(f"Version: {utils.VERSION}")
+"#;
+
+    let utils_ast = parse_python(utils_code).expect("Failed to parse utils");
+    let main_ast = parse_python(main_code).expect("Failed to parse main");
+
+    let mut bundler = StaticBundler::new();
+
+    // Create module nodes for dependency order
+    let utils_node = ModuleNode {
+        name: "utils".to_string(),
+        path: PathBuf::from("utils.py"),
+        imports: vec![],
+    };
+
+    let main_node = ModuleNode {
+        name: "main".to_string(),
+        path: PathBuf::from("main.py"),
+        imports: vec!["utils".to_string()],
+    };
+
+    let sorted_nodes = vec![&utils_node, &main_node];
+
+    // Bundle the modules
+    let modules = vec![
+        ("utils".to_string(), utils_ast),
+        ("main".to_string(), main_ast),
+    ];
+
+    let bundled_ast = bundler
+        .bundle_modules(modules, &sorted_nodes)
+        .expect("Failed to bundle modules");
+
+    // Check that we have wrapper classes for non-entry modules
+    let has_utils_wrapper = bundled_ast.body.iter().any(|stmt| {
+        matches!(stmt, Stmt::ClassDef(class_def) if class_def.name.as_str() == "__cribo_module_utils")
+    });
+
+    // The entry module (main) should NOT be wrapped - it executes directly
+    let has_main_wrapper = bundled_ast.body.iter().any(|stmt| {
+        matches!(stmt, Stmt::ClassDef(class_def) if class_def.name.as_str() == "__cribo_module_main")
+    });
+
+    assert!(has_utils_wrapper, "Should have utils wrapper class");
+    assert!(
+        !has_main_wrapper,
+        "Entry module should NOT be wrapped in class"
+    );
+
+    // Check that imports have been rewritten
+    let generated_code = generate_python(&bundled_ast);
+
+    // Should not contain "import utils" anymore
+    assert!(
+        !generated_code.contains("import utils"),
+        "Import should be rewritten"
+    );
+
+    // Should have module facade creation
+    assert!(
+        generated_code.contains("types.ModuleType"),
+        "Should create module facades"
+    );
+
+    // Should have initialization calls
+    assert!(
+        generated_code.contains("__cribo_init"),
+        "Should have init calls"
+    );
+}
+
+#[test]
+fn test_multi_module_with_dependencies() {
+    let config_code = r#"
+DEBUG = True
+API_KEY = "secret"
+"#;
+
+    let database_code = r#"
+import config
+
+def connect():
+    if config.DEBUG:
+        print("Debug mode enabled")
+    return "Connected"
+"#;
+
+    let api_code = r#"
+import config
+import database
+
+def make_request():
+    conn = database.connect()
+    return f"API request with key: {config.API_KEY[:4]}..."
+"#;
+
+    let config_ast = parse_python(config_code).expect("Failed to parse config");
+    let database_ast = parse_python(database_code).expect("Failed to parse database");
+    let api_ast = parse_python(api_code).expect("Failed to parse api");
+
+    let mut bundler = StaticBundler::new();
+
+    // Create module nodes
+    let config_node = ModuleNode {
+        name: "config".to_string(),
+        path: PathBuf::from("config.py"),
+        imports: vec![],
+    };
+
+    let database_node = ModuleNode {
+        name: "database".to_string(),
+        path: PathBuf::from("database.py"),
+        imports: vec!["config".to_string()],
+    };
+
+    let api_node = ModuleNode {
+        name: "api".to_string(),
+        path: PathBuf::from("api.py"),
+        imports: vec!["config".to_string(), "database".to_string()],
+    };
+
+    let sorted_nodes = vec![&config_node, &database_node, &api_node];
+
+    // Bundle the modules
+    let modules = vec![
+        ("config".to_string(), config_ast),
+        ("database".to_string(), database_ast),
+        ("api".to_string(), api_ast),
+    ];
+
+    let bundled_ast = bundler
+        .bundle_modules(modules, &sorted_nodes)
+        .expect("Failed to bundle modules");
+
+    // Verify wrapper classes exist for non-entry modules
+    // Entry module (api) should not be wrapped
+    let wrapper_count = bundled_ast.body.iter().filter(|stmt| {
+        matches!(stmt, Stmt::ClassDef(class_def) if class_def.name.as_str().starts_with("__cribo_module_"))
+    }).count();
+
+    assert_eq!(
+        wrapper_count, 2,
+        "Should have 2 wrapper classes (config and database, but not api)"
+    );
+
+    let generated_code = generate_python(&bundled_ast);
+
+    // Verify imports are rewritten
+    assert!(
+        !generated_code.contains("import config"),
+        "Config import should be rewritten"
+    );
+    assert!(
+        !generated_code.contains("import database"),
+        "Database import should be rewritten"
+    );
+}
+
+#[test]
+fn test_module_with_initialization_code() {
+    let module_code = r#"
+# Module with initialization code
+print("Loading module...")
+
+counter = 0
+items = []
+
+if __name__ != "__main__":
+    counter += 1
+    items.append("initialized")
+
+def get_counter():
+    return counter
+"#;
+
+    let module_ast = parse_python(module_code).expect("Failed to parse module");
+
+    let mut bundler = StaticBundler::new();
+    let wrapped = bundler
+        .wrap_module("test_module", module_ast)
+        .expect("Failed to wrap module");
+
+    // Check that we have __cribo_init method
+    let class_body = match &wrapped.transformed_ast.body[0] {
+        Stmt::ClassDef(class_def) => &class_def.body,
+        _ => panic!("Expected class definition"),
+    };
+
+    let has_cribo_init = class_body.iter().any(
+        |stmt| matches!(stmt, Stmt::FunctionDef(func) if func.name.as_str() == "__cribo_init"),
+    );
+
+    assert!(
+        has_cribo_init,
+        "Should have __cribo_init method for initialization code"
+    );
+}
+
+#[test]
+fn test_nested_module_structure() {
+    let models_user_code = r#"
+class User:
+    def __init__(self, name):
+        self.name = name
+"#;
+
+    let models_init_code = r#"
+from .user import User
+
+__all__ = ["User"]
+"#;
+
+    let main_code = r#"
+from models import User
+
+user = User("Alice")
+print(user.name)
+"#;
+
+    let models_user_ast = parse_python(models_user_code).expect("Failed to parse models.user");
+    let models_init_ast = parse_python(models_init_code).expect("Failed to parse models.__init__");
+    let main_ast = parse_python(main_code).expect("Failed to parse main");
+
+    let mut bundler = StaticBundler::new();
+
+    // Create module nodes
+    let models_user_node = ModuleNode {
+        name: "models.user".to_string(),
+        path: PathBuf::from("models/user.py"),
+        imports: vec![],
+    };
+
+    let models_node = ModuleNode {
+        name: "models".to_string(),
+        path: PathBuf::from("models/__init__.py"),
+        imports: vec!["models.user".to_string()],
+    };
+
+    let main_node = ModuleNode {
+        name: "main".to_string(),
+        path: PathBuf::from("main.py"),
+        imports: vec!["models".to_string()],
+    };
+
+    let sorted_nodes = vec![&models_user_node, &models_node, &main_node];
+
+    // Bundle the modules
+    let modules = vec![
+        ("models.user".to_string(), models_user_ast),
+        ("models".to_string(), models_init_ast),
+        ("main".to_string(), main_ast),
+    ];
+
+    let bundled_ast = bundler
+        .bundle_modules(modules, &sorted_nodes)
+        .expect("Failed to bundle modules");
+
+    // Check that nested module structure is created
+    let generated_code = generate_python(&bundled_ast);
+
+    // Should create nested module structure
+    assert!(
+        generated_code.contains("models"),
+        "Should have models module"
+    );
+
+    // Should handle relative imports properly
+    assert!(
+        generated_code.contains("__cribo_module_models_user"),
+        "Should have models.user wrapper"
+    );
+}

--- a/docs/no-runtime-eval-sd.md
+++ b/docs/no-runtime-eval-sd.md
@@ -1,0 +1,534 @@
+# System Design: Static Python Bundle Generation Without Runtime Code Evaluation
+
+## Executive Summary
+
+This document outlines a comprehensive refactoring strategy to eliminate runtime code evaluation (`exec()`) from cribo's bundled output. Instead, we'll generate a single, statically analyzable Python file where all modules are inlined with proper namespace isolation through AST transformations.
+
+## Current State Analysis
+
+### Problems with Current Approach
+
+1. **Runtime `exec()` usage**: Modules are wrapped in `exec()` calls, making the code:
+   - Harder for AI models to analyze
+   - Slower at runtime due to dynamic compilation
+   - Impossible to generate accurate source maps
+   - Difficult to debug with standard Python tools
+
+2. **Namespace complexity**: The current approach creates module objects dynamically and executes code into their namespaces, requiring complex globals/locals manipulation.
+
+3. **Lost optimization opportunities**: Dead code elimination and other optimizations are limited by the dynamic nature.
+
+## Proposed Solution: Static Module Inlining
+
+### Core Concept
+
+Transform the bundled output from:
+
+```python
+# Current approach
+import types
+models = types.ModuleType('models')
+models.user = types.ModuleType('models.user')
+exec('class User: ...', globals(), models.user.__dict__)
+```
+
+To:
+
+```python
+# Proposed approach
+class __cribo_module_models_user:
+    class User:
+        ...
+    
+    # Module-level variables
+    __cribo_vars = {
+        'DEFAULT_CONFIG': {'debug': True}
+    }
+
+# Create module facade
+import types
+models = types.ModuleType('models')
+models.user = types.ModuleType('models.user')
+# Copy all public attributes
+for __name in dir(__cribo_module_models_user):
+    if not __name.startswith('_'):
+        setattr(models.user, __name, getattr(__cribo_module_models_user, __name))
+# Copy module-level variables
+for __k, __v in __cribo_module_models_user.__cribo_vars.items():
+    setattr(models.user, __k, __v)
+```
+
+## Detailed Implementation Strategy
+
+### Phase 1: AST Transformation Framework
+
+#### 1.1 Module Wrapper Generation
+
+Create a new AST transformer that wraps each module's content in a class:
+
+```rust
+// src/static_bundler.rs
+pub struct StaticBundler {
+    module_registry: IndexMap<String, WrappedModule>,
+}
+
+struct WrappedModule {
+    wrapper_class_name: String, // e.g., "__cribo_module_models_user"
+    original_name: String,      // e.g., "models.user"
+    transformed_ast: ModModule,
+}
+
+impl StaticBundler {
+    fn wrap_module(&mut self, module_name: &str, ast: ModModule) -> Result<WrappedModule> {
+        let wrapper_class_name = self.generate_wrapper_name(module_name);
+        let wrapped_ast = self.transform_module_to_class(module_name, ast)?;
+
+        Ok(WrappedModule {
+            wrapper_class_name,
+            original_name: module_name.to_string(),
+            transformed_ast: wrapped_ast,
+        })
+    }
+
+    fn generate_wrapper_name(&self, module_name: &str) -> String {
+        format!("__cribo_module_{}", module_name.replace('.', "_"))
+    }
+}
+```
+
+#### 1.2 AST Transformation Rules
+
+Transform module-level code into class methods and attributes:
+
+```rust
+fn transform_module_to_class(&self, module_name: &str, mut ast: ModModule) -> Result<ModModule> {
+    let mut class_body = Vec::new();
+    let mut module_vars = IndexMap::new();
+
+    for stmt in ast.body {
+        match stmt {
+            // Functions become class methods
+            Stmt::FunctionDef(mut func) => {
+                // Add @staticmethod decorator
+                func.decorator_list.push(create_staticmethod_decorator());
+                class_body.push(Stmt::FunctionDef(func));
+            }
+
+            // Classes remain as nested classes
+            Stmt::ClassDef(class_def) => {
+                class_body.push(Stmt::ClassDef(class_def));
+            }
+
+            // Module-level assignments go to __cribo_vars
+            Stmt::Assign(assign) => {
+                if let Some(name) = extract_simple_target(&assign) {
+                    module_vars.insert(name, assign.value);
+                } else {
+                    // Complex assignments need special handling
+                    class_body.push(create_init_method_statement(assign));
+                }
+            }
+
+            // Import statements need special handling
+            Stmt::Import(_) | Stmt::ImportFrom(_) => {
+                // These are already hoisted, skip
+            }
+
+            // Other statements (if, for, etc.) go into __cribo_init
+            _ => {
+                class_body.push(create_init_method_statement(stmt));
+            }
+        }
+    }
+
+    // Add __cribo_vars as class attribute
+    if !module_vars.is_empty() {
+        class_body.push(create_module_vars_assignment(module_vars));
+    }
+
+    // Create the wrapper class
+    let wrapper_class = create_class_def(&self.generate_wrapper_name(module_name), class_body);
+
+    Ok(ModModule {
+        body: vec![wrapper_class],
+        range: TextRange::default(),
+    })
+}
+```
+
+### Phase 2: Import Resolution and Variable Access
+
+#### 2.1 Import Rewriting
+
+Transform imports to reference the wrapper classes:
+
+```rust
+fn rewrite_imports(&mut self, stmt: Stmt) -> Result<Stmt> {
+    match stmt {
+        Stmt::ImportFrom(import_from) => {
+            if let Some(module) = &import_from.module {
+                if self.is_bundled_module(&module.id) {
+                    // Transform: from models.user import User
+                    // To: User = __cribo_module_models_user.User
+                    return self.create_wrapper_import(&import_from);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(stmt)
+}
+
+fn create_wrapper_import(&self, import_from: &StmtImportFrom) -> Result<Stmt> {
+    let wrapper_name = self.generate_wrapper_name(&import_from.module.as_ref().unwrap().id);
+    let mut assignments = Vec::new();
+
+    for alias in &import_from.names {
+        let target = create_name_expr(&alias.name.id, ExprContext::Store);
+        let value = create_attribute_expr(
+            create_name_expr(&wrapper_name, ExprContext::Load),
+            &alias.name.id,
+            ExprContext::Load,
+        );
+
+        assignments.push(create_assignment(target, value));
+    }
+
+    // Return multiple assignments as a single statement block
+    Ok(create_statement_block(assignments))
+}
+```
+
+#### 2.2 Module-Level Variable Access
+
+Handle access to module-level variables:
+
+```python
+# Generated code pattern
+class __cribo_module_config:
+    @staticmethod
+    def get_config():
+        # Access module variable through the class
+        return __cribo_module_config.__cribo_vars['DEFAULT_CONFIG'].copy()
+    
+    __cribo_vars = {
+        'DEFAULT_CONFIG': {'debug': True, 'timeout': 30}
+    }
+```
+
+### Phase 3: Module Initialization
+
+#### 3.1 Initialization Order
+
+Maintain proper initialization order for modules with side effects:
+
+```rust
+fn generate_module_initializers(&self, sorted_modules: &[&ModuleNode]) -> Vec<Stmt> {
+    let mut initializers = Vec::new();
+
+    for module in sorted_modules {
+        let wrapper_name = self.generate_wrapper_name(&module.name);
+
+        // Check if module has __cribo_init method
+        if self.module_has_init_code(&module.name) {
+            // Call the initialization method
+            let init_call = create_method_call(&wrapper_name, "__cribo_init");
+            initializers.push(create_expr_stmt(init_call));
+        }
+    }
+
+    initializers
+}
+```
+
+#### 3.2 Module Facade Creation
+
+Generate code to create the module facades that maintain compatibility:
+
+```rust
+fn generate_module_facades(&self) -> Vec<Stmt> {
+    let mut facades = Vec::new();
+
+    // Import types module
+    facades.push(create_import("types"));
+
+    for (module_name, wrapped) in &self.module_registry {
+        // Create module hierarchy
+        let parts: Vec<&str> = module_name.split('.').collect();
+
+        // Create parent modules first
+        for i in 1..=parts.len() {
+            let partial_name = parts[..i].join(".");
+            facades.extend(self.create_module_object(&partial_name, i == 1));
+        }
+
+        // Copy attributes from wrapper to module
+        facades.extend(self.create_attribute_copying(&wrapped));
+    }
+
+    facades
+}
+
+fn create_attribute_copying(&self, wrapped: &WrappedModule) -> Vec<Stmt> {
+    // Generate:
+    // for __attr in dir(__cribo_module_X):
+    //     if not __attr.startswith('_') or __attr == '__all__':
+    //         setattr(module.x, __attr, getattr(__cribo_module_X, __attr))
+
+    let wrapper_name = &wrapped.wrapper_class_name;
+    let module_expr = self.create_module_reference(&wrapped.original_name);
+
+    vec![
+        create_attribute_copy_loop(wrapper_name, module_expr),
+        create_vars_copy_statement(wrapper_name, module_expr),
+    ]
+}
+```
+
+### Phase 4: Special Cases Handling
+
+#### 4.1 Circular Dependencies
+
+For circular dependencies, we need lazy initialization:
+
+```python
+# Generated code for circular deps
+class __cribo_module_a:
+    @staticmethod
+    def func_that_imports_b():
+        # Lazy import at function level
+        from __cribo_module_b import something
+        return something()
+
+class __cribo_module_b:
+    @staticmethod  
+    def func_that_imports_a():
+        # Lazy import at function level
+        from __cribo_module_a import something_else
+        return something_else()
+```
+
+#### 4.2 `__all__` Exports
+
+Handle `__all__` declarations specially:
+
+```rust
+fn handle_all_exports(&mut self, module_name: &str, all_value: &Expr) -> Result<()> {
+    // Extract the list of exported names
+    let exported_names = extract_string_list(all_value)?;
+
+    // Store for later use when creating module facade
+    self.module_exports
+        .insert(module_name.to_string(), exported_names);
+
+    // Also add __all__ to the wrapper class
+    Ok(())
+}
+```
+
+### Phase 5: Output Generation
+
+#### 5.1 Final Bundle Structure
+
+```python
+#!/usr/bin/env python3
+# Generated by Cribo - Python Source Bundler
+
+# Standard library imports (hoisted)
+import os
+import sys
+from typing import Optional
+
+# Module wrapper classes
+class __cribo_module_models_user:
+    class User:
+        def __init__(self, name: str):
+            self.name = name
+    
+    __cribo_vars = {}
+
+class __cribo_module_utils_helpers:
+    @staticmethod
+    def helper_func():
+        return "helper"
+    
+    __cribo_vars = {}
+
+# Module initialization
+# (any module-level code that needs to run)
+
+# Create module facades
+import types
+models = types.ModuleType('models')
+models.user = types.ModuleType('models.user')
+
+# Copy attributes
+for __attr in dir(__cribo_module_models_user):
+    if not __attr.startswith('_'):
+        setattr(models.user, __attr, getattr(__cribo_module_models_user, __attr))
+
+# ... more module setup ...
+
+# Entry point code
+def main():
+    from models.user import User  # This now references __cribo_module_models_user.User
+    user = User("Alice")
+    print(user.name)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Phase 6: Source Map Generation
+
+With static code generation, we can now generate accurate source maps:
+
+```rust
+pub struct SourceMap {
+    version: u32,
+    sources: Vec<String>,
+    mappings: String, // VLQ encoded mappings
+}
+
+impl StaticBundler {
+    fn generate_source_map(&self, bundled_ast: &ModModule) -> Result<SourceMap> {
+        let mut mapper = SourceMapper::new();
+
+        for stmt in &bundled_ast.body {
+            if let Some(original_location) = self.get_original_location(stmt) {
+                let bundled_location = self.get_bundled_location(stmt);
+                mapper.add_mapping(original_location, bundled_location);
+            }
+        }
+
+        Ok(mapper.build())
+    }
+}
+```
+
+## Migration Strategy
+
+### Step 1: Implement Core Transformation
+
+1. Create `static_bundler.rs` with the basic AST transformation logic
+2. Add tests for simple module wrapping
+3. Implement attribute copying mechanism
+
+### Step 2: Handle Import Resolution
+
+1. Implement import rewriting for bundled modules
+2. Add support for relative imports
+3. Handle circular dependencies with lazy imports
+
+### Step 3: Module Variables
+
+1. Implement `__cribo_vars` dictionary approach
+2. Transform variable access in functions
+3. Handle complex assignment patterns
+
+### Step 4: Integration
+
+1. Add configuration option to use static bundling
+2. Migrate existing tests to verify compatibility
+3. Implement source map generation
+
+### Step 5: Optimization
+
+1. Add dead code elimination pass
+2. Implement constant folding where possible
+3. Minimize generated wrapper code
+
+## Benefits
+
+1. **AI Model Friendly**: Clean, static Python code without `exec()`
+2. **Performance**: No runtime code compilation overhead
+3. **Debuggability**: Standard Python debugging tools work
+4. **Source Maps**: Accurate mapping back to original files
+5. **Static Analysis**: Tools like mypy, pylint work on output
+6. **Security**: No dynamic code evaluation risks
+
+## Challenges and Solutions
+
+### Challenge 1: Module-Level Code Execution Order
+
+**Solution**: Use `__cribo_init()` methods called in dependency order
+
+### Challenge 2: Dynamic Imports
+
+**Solution**: Convert to static imports where possible, warn for truly dynamic cases
+
+### Challenge 3: Global State
+
+**Solution**: Isolate in `__cribo_vars` dictionaries per module
+
+## Example Transformation
+
+### Input (multiple files)
+
+```python
+# models/user.py
+from dataclasses import dataclass
+
+DEFAULT_USER_TYPE = "standard"
+
+@dataclass
+class User:
+    name: str
+    user_type: str = DEFAULT_USER_TYPE
+    
+    def greet(self):
+        return f"Hello, {self.name}"
+
+# main.py
+from models.user import User
+
+user = User("Alice")
+print(user.greet())
+```
+
+### Output (single file)
+
+```python
+#!/usr/bin/env python3
+# Generated by Cribo
+
+from dataclasses import dataclass
+
+# Module: models.user
+class __cribo_module_models_user:
+    @dataclass
+    class User:
+        name: str
+        user_type: str = None
+        
+        def __post_init__(self):
+            if self.user_type is None:
+                self.user_type = __cribo_module_models_user.__cribo_vars['DEFAULT_USER_TYPE']
+        
+        def greet(self):
+            return f"Hello, {self.name}"
+    
+    __cribo_vars = {
+        'DEFAULT_USER_TYPE': "standard"
+    }
+
+# Create module facades
+import types
+models = types.ModuleType('models')
+models.user = types.ModuleType('models.user')
+
+for __attr in dir(__cribo_module_models_user):
+    if not __attr.startswith('_'):
+        setattr(models.user, __attr, getattr(__cribo_module_models_user, __attr))
+
+for __k, __v in __cribo_module_models_user.__cribo_vars.items():
+    setattr(models.user, __k, __v)
+
+# Entry point
+User = __cribo_module_models_user.User
+
+user = User("Alice")
+print(user.greet())
+```
+
+This approach eliminates all runtime code evaluation while maintaining full compatibility with Python's module system, enabling better performance, debuggability, and tool integration.

--- a/docs/static-bundling.md
+++ b/docs/static-bundling.md
@@ -1,0 +1,196 @@
+# Static Bundling System Design
+
+## Overview
+
+The static bundling feature in Cribo eliminates the use of runtime `exec()` calls by transforming Python modules into wrapper classes. This approach addresses compatibility issues with certain Python environments where `exec()` is restricted or problematic, particularly when dealing with hoisted stdlib imports.
+
+## Problem Statement
+
+The traditional bundling approach uses `exec()` to execute module code in isolated namespaces. This causes issues when:
+
+- Hoisted standard library imports are not accessible within the exec'd code
+- Security-restricted environments block or limit `exec()` usage
+- Debugging becomes difficult due to dynamic code execution
+- Performance overhead from runtime code compilation
+
+## Solution Architecture
+
+### Core Concept
+
+Transform each Python module into a wrapper class where:
+
+- Functions become static methods
+- Module-level variables are stored in a `__cribo_vars` dictionary
+- Complex initialization code goes into a `__cribo_init` classmethod
+- Classes remain as nested classes within the wrapper
+
+### Module Transformation
+
+Each module `foo.bar` is transformed into a class `__cribo_module_foo_bar`:
+
+```python
+# Original module: foo/bar.py
+VERSION = "1.0.0"
+DEBUG = True
+
+def helper(x):
+    return x * 2
+
+class Config:
+    timeout = 30
+
+# Complex initialization
+if DEBUG:
+    print("Debug mode enabled")
+```
+
+```python
+# Transformed module
+class __cribo_module_foo_bar:
+    __cribo_vars = {
+        'VERSION': "1.0.0",
+        'DEBUG': True
+    }
+    
+    @staticmethod
+    def helper(x):
+        return x * 2
+    
+    class Config:
+        timeout = 30
+    
+    @classmethod
+    def __cribo_init(cls):
+        if DEBUG:
+            print("Debug mode enabled")
+```
+
+### Module Facade System
+
+After transformation, module facades are created to maintain Python's import semantics:
+
+```python
+import types
+
+# Create module objects
+foo = types.ModuleType('foo')
+foo.bar = types.ModuleType('foo.bar')
+
+# Copy attributes from wrapper to module
+for __attr in dir(__cribo_module_foo_bar):
+    if not __attr.startswith('_'):
+        setattr(foo.bar, __attr, getattr(__cribo_module_foo_bar, __attr))
+
+# Copy module variables
+if hasattr(__cribo_module_foo_bar, '__cribo_vars'):
+    for __k, __v in __cribo_module_foo_bar.__cribo_vars.items():
+        setattr(foo.bar, __k, __v)
+
+# Run initialization code
+if hasattr(__cribo_module_foo_bar, '__cribo_init'):
+    __cribo_module_foo_bar.__cribo_init()
+```
+
+### Import Rewriting
+
+Import statements for bundled modules are handled specially:
+
+1. **Simple imports** (`import foo`) - Removed entirely as module objects are pre-created
+2. **From imports** (`from foo import bar`) - Converted to attribute access:
+   ```python
+   # Original
+   from foo import bar
+
+   # Transformed
+   bar = getattr(foo, 'bar')
+   ```
+
+### Entry Module Handling
+
+The entry module receives special treatment:
+
+- Its code executes directly in the global scope (not wrapped in a class)
+- This ensures the main script behaves as expected
+- Import statements in the entry module are still rewritten to use bundled modules
+
+## Implementation Details
+
+### AST Transformation Rules
+
+1. **Functions** → Static methods with `@staticmethod` decorator
+2. **Classes** → Nested classes (unchanged)
+3. **Simple assignments** → Stored in `__cribo_vars` if they don't reference other variables
+4. **Complex assignments** → Placed in `__cribo_init` method
+5. **Import statements** → Filtered out during transformation
+6. **Control flow statements** → Placed in `__cribo_init` method
+7. **Expression statements** → Placed in `__cribo_init` method
+
+### Variable Reference Detection
+
+The bundler analyzes assignment values to determine placement:
+
+- Literals and constants → `__cribo_vars`
+- Expressions with variable references → `__cribo_init`
+
+This ensures variables are initialized in the correct order.
+
+### Module Initialization Order
+
+1. Transform all non-entry modules into wrapper classes
+2. Create module facade objects (types.ModuleType)
+3. Copy attributes from wrappers to module objects
+4. Execute `__cribo_init` methods in dependency order
+5. Execute entry module code directly
+
+## Benefits
+
+1. **No exec() calls** - Compatible with restricted environments
+2. **Better debugging** - Stack traces show actual class/method names
+3. **Static analysis friendly** - Tools can analyze the bundled code
+4. **Performance** - No runtime code compilation overhead
+5. **Security** - Reduced attack surface without dynamic execution
+
+## Limitations
+
+1. **Dynamic module manipulation** - Code that modifies `__dict__` directly may not work
+2. **Module reload** - `importlib.reload()` won't work as expected
+3. **Circular imports** - Handled but may require careful initialization ordering
+4. **Bundle size** - Slightly larger due to wrapper infrastructure
+
+## Configuration
+
+Enable static bundling via:
+
+```toml
+# cribo.toml
+[bundler]
+static-bundling = true
+```
+
+Or via CLI:
+
+```bash
+cribo --entry main.py --output bundle.py --static-bundling
+```
+
+Or via environment variable:
+
+```bash
+CRIBO_STATIC_BUNDLING=true cribo --entry main.py --output bundle.py
+```
+
+## Future Enhancements
+
+1. **Optimization passes** - Remove unnecessary wrapper overhead for simple modules
+2. **Source maps** - Map bundled code back to original files for debugging
+3. **Lazy module loading** - Defer module initialization until first access
+4. **Tree shaking** - Remove unused module attributes from bundles
+5. **Type preservation** - Maintain type hints in transformed code
+
+## Testing Strategy
+
+1. **Unit tests** - Test individual transformation rules
+2. **Integration tests** - Test full bundling pipeline
+3. **Compatibility tests** - Ensure feature parity with exec-based bundling
+4. **Performance benchmarks** - Compare with traditional bundling
+5. **Real-world projects** - Test with complex Python applications


### PR DESCRIPTION
## Summary

This PR implements a static bundling system that transforms Python modules into wrapper classes, eliminating the need for runtime `exec()` calls. This addresses the issue from #103 where hoisted stdlib imports weren't accessible in exec'd code.

## Key Changes

- **New static bundler**: Transforms modules into wrapper classes with functions as static methods
- **Module facade system**: Creates `types.ModuleType` objects to maintain Python import semantics  
- **Import rewriting**: Converts imports of bundled modules to use pre-created facades
- **Entry module handling**: Executes entry module code directly in global scope
- **Performance optimization**: Skips transformation when only entry module is present

## Technical Details

### Module Transformation
```python
# Original module
VERSION = "1.0.0"
def helper(x):
    return x * 2

# Transformed to wrapper class
class __cribo_module_foo:
    __cribo_vars = {'VERSION': "1.0.0"}
    
    @staticmethod
    def helper(x):
        return x * 2
```

### Benefits
- ✅ No `exec()` calls - compatible with restricted environments
- ✅ Better debugging - real stack traces with class/method names
- ✅ Static analysis friendly
- ✅ No runtime code compilation overhead
- ✅ Passes through unchanged files with no first-party imports

### Configuration
```bash
# Via CLI flag
cribo --entry main.py --output bundle.py --static-bundling

# Via config file
[bundler]
static-bundling = true
```

## Test Results
- All existing tests pass
- Added comprehensive unit and integration tests for static bundling
- Verified compatibility with existing bundling features

## Related Issues
- Fixes #103 (hoisted stdlib imports not accessible in exec'd code)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>