### PR TITLE
fix(deps): upgrade ruff crates from 0.11.12 to 0.11.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +791,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1656,7 +1672,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "ruff_annotate_snippets"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "anstyle",
  "memchr",
@@ -1666,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "ruff_cache"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "filetime",
  "glob",
@@ -1679,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "ruff_db"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "anstyle",
  "camino",
@@ -1708,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "ruff_diagnostics"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "is-macro",
  "ruff_text_size",
@@ -1718,15 +1734,15 @@ dependencies = [
 [[package]]
 name = "ruff_index"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "ruff_macros",
 ]
 
 [[package]]
 name = "ruff_linter"
-version = "0.11.12"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+version = "0.11.13"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1785,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "ruff_macros"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -1798,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "ruff_notebook"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1816,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "aho-corasick",
  "bitflags",
@@ -1836,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_codegen"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "ruff_python_ast",
  "ruff_python_literal",
@@ -1848,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_index"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
@@ -1860,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_literal"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "bitflags",
  "itertools 0.14.0",
@@ -1871,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "bitflags",
  "bstr",
@@ -1890,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_semantic"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1908,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_stdlib"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "bitflags",
  "unicode-ident",
@@ -1917,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "itertools 0.14.0",
  "ruff_source_file",
@@ -1928,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -1938,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?rev=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
+source = "git+https://github.com/astral-sh/ruff/?rev=0.11.13#5faf72a4d9b50c6e330165685e57fae14ca68b73"
 dependencies = [
  "serde",
 ]
@@ -1986,12 +2002,13 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
-version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=4818b15f3b7516555d39f5a41cb75970448bee4c#4818b15f3b7516555d39f5a41cb75970448bee4c"
+version = "0.22.0"
+source = "git+https://github.com/carljm/salsa.git?rev=0f6d406f6c309964279baef71588746b8c67b4a3#0f6d406f6c309964279baef71588746b8c67b4a3"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
  "dashmap",
+ "hashbrown 0.14.5",
  "hashbrown 0.15.4",
  "hashlink",
  "indexmap",
@@ -2008,15 +2025,14 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=4818b15f3b7516555d39f5a41cb75970448bee4c#4818b15f3b7516555d39f5a41cb75970448bee4c"
+version = "0.22.0"
+source = "git+https://github.com/carljm/salsa.git?rev=0f6d406f6c309964279baef71588746b8c67b4a3#0f6d406f6c309964279baef71588746b8c67b4a3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=4818b15f3b7516555d39f5a41cb75970448bee4c#4818b15f3b7516555d39f5a41cb75970448bee4c"
+version = "0.22.0"
+source = "git+https://github.com/carljm/salsa.git?rev=0f6d406f6c309964279baef71588746b8c67b4a3#0f6d406f6c309964279baef71588746b8c67b4a3"
 dependencies = [
- "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ once_cell = "1.21.3"
 clap = { version = "4.5.39", features = ["derive"] }
 
 # Python parsing - using git dependencies as ruff internals are not published to crates.io
-ruff_linter = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_codegen = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_semantic = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_python_trivia = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.12" }
+ruff_linter = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_codegen = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_semantic = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_python_trivia = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "0.11.13" }
 
 # Serialization and configuration
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cribo/src/graph_builder.rs
+++ b/crates/cribo/src/graph_builder.rs
@@ -824,7 +824,7 @@ impl<'a> GraphBuilder<'a> {
             Expr::FString(fstring) => {
                 // Process f-string value parts
                 for element in fstring.value.elements() {
-                    if let ast::FStringElement::Expression(expr_element) = element {
+                    if let ast::InterpolatedStringElement::Interpolation(expr_element) = element {
                         self.collect_vars_in_expr(&expr_element.expression, vars);
                     }
                 }

--- a/crates/cribo/tests/test_bundling_snapshots.rs
+++ b/crates/cribo/tests/test_bundling_snapshots.rs
@@ -100,20 +100,19 @@ fn run_ruff_lint_on_bundle(bundled_code: &str) -> RuffLintResults {
     let mut other_violations = Vec::new();
 
     for message in &result.messages {
-        if let Some(rule) = message.to_rule() {
-            let location = message.compute_start_location();
-            let violation_info = format!(
-                "Line {}: {} - {}",
-                location.line.get(),
-                rule.noqa_code(),
-                message.body()
-            );
+        let location = message.compute_start_location();
+        let rule_name = message.name();
+        let violation_info = format!(
+            "Line {}: {} - {}",
+            location.line.get(),
+            rule_name,
+            message.body()
+        );
 
-            match rule {
-                Rule::UnusedImport => f401_violations.push(violation_info),
-                Rule::LateFutureImport => f404_violations.push(violation_info),
-                _ => other_violations.push(violation_info),
-            }
+        match rule_name {
+            "F401" => f401_violations.push(violation_info),
+            "F404" => f404_violations.push(violation_info),
+            _ => other_violations.push(violation_info),
         }
     }
 


### PR DESCRIPTION
## **User description**
## Summary

This PR upgrades the ruff crates from version 0.11.12 to 0.11.13 to stay current with the latest improvements and fixes.

## Changes

### Dependency Updates
- Updated all ruff dependencies in `Cargo.toml` to version 0.11.13

### API Migration
The ruff 0.11.13 release included breaking changes to the FString AST representation. This PR includes the necessary code changes to adapt to the new API:

#### FString AST Changes
- `FStringElement` → `InterpolatedStringElement`
- `FStringElements` → `InterpolatedStringElements`
- `FStringExpressionElement` → `InterpolatedElement`
- `FStringElement::Expression` → `InterpolatedStringElement::Interpolation`
- `FStringElement::Literal` → `InterpolatedStringElement::Literal`

#### Message API Changes
- `message.to_rule()` → `message.name()` (now returns rule code strings like "F401")

### Files Modified
- `crates/cribo/src/code_generator.rs` - Updated FString transformation logic
- `crates/cribo/src/graph_builder.rs` - Updated FString AST traversal
- `crates/cribo/tests/test_bundling_snapshots.rs` - Updated test assertions for new Message API
- `Cargo.lock` - Dependency updates

## Test Results

✅ All tests passing:
```bash
cargo test --workspace
# test result: ok. 90 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

✅ Zero clippy warnings:
```bash
cargo clippy --workspace --all-targets
# Finished with 0 warnings
```

## Compatibility

This change is backward compatible for users of cribo as it only updates internal dependencies and adapts to their API changes. The public API of cribo remains unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
- Upgraded all ruff-related dependencies in `Cargo.toml` from version 0.11.12 to 0.11.13.
- Migrated f-string AST handling throughout the codebase to use the new `InterpolatedStringElement`, `InterpolatedStringElements`, and `InterpolatedElement` types and enum variants, replacing the old `FString*` types.
- Updated f-string transformation and traversal logic in both the code generator and graph builder modules to align with the new ruff AST API.
- Refactored test code to use the new `message.name()` API for rule identification, replacing the deprecated `message.to_rule()`.

This PR modernizes the codebase to be compatible with ruff 0.11.13, ensuring continued compatibility and benefiting from upstream improvements. The changes are internal and do not affect the public API, maintaining backward compatibility for users.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Upgrade ruff dependencies to version 0.11.13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml
<li>Upgraded all <code>ruff_*</code> dependencies from version 0.11.12 to 0.11.13.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/122/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_generator.rs</strong><dd><code>Migrate f-string AST handling to new ruff API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cribo/src/code_generator.rs
<li>Migrated all usage of <code>FStringElement</code>, <code>FStringElements</code>, and <br><code>FStringExpressionElement</code> to <code>InterpolatedStringElement</code>, <br><code>InterpolatedStringElements</code>, and <code>InterpolatedElement</code> respectively, <br>reflecting the updated ruff AST API.<br> <li> Updated f-string transformation logic to use new enum variants <br>(<code>Interpolation</code> and <code>Literal</code>) and types.<br> <li> Adjusted function signatures and internal logic to match new AST <br>structures.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/122/files#diff-c161e86d0f1bfc649f3989ca702cb4cc7ef92f0488634273d367b2d00fa86e3d">+22/-17</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph_builder.rs</strong><dd><code>Update f-string AST traversal for new ruff API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cribo/src/graph_builder.rs
<li>Updated f-string AST traversal to use <br><code>InterpolatedStringElement::Interpolation</code> instead of the old <br><code>FStringElement::Expression</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/122/files#diff-3cd1dd8d371b7ec18c944fc1bd8c586ea13e1387591bb379de69a7781b3c6c6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bundling_snapshots.rs</strong><dd><code>Update test suite for new ruff message API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cribo/tests/test_bundling_snapshots.rs
<li>Updated test assertions to use <code>message.name()</code> (returning rule codes <br>like "F401") instead of the deprecated <code>message.to_rule()</code>.<br> <li> Adjusted test logic to match new ruff message API.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/122/files#diff-0b27b1106e4557045f8737717e61a4cdb3945412510cc8fa02f08bc60fa5bcdc">+13/-14</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of f-string expressions for better compatibility and accuracy in code transformation and analysis.
  - Updated classification of lint violation messages to use rule names directly, simplifying reporting and improving clarity.

- **Chores**
  - Updated dependency versions for ruff-related components to ensure up-to-date tooling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->