### PR TITLE
feat(ci): only show rust analyzer for changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,12 +122,23 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const ref = context.payload.pull_request.head.sha;
+            // Fetch list of changed files in this PR
+            const changedFilesList = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: context.issue.number }
+            );
+            const changedFiles = new Set(changedFilesList.map(f => f.filename));
             let rows = [];
             const collectFiles = (d) => fs.readdirSync(d, { withFileTypes: true }).flatMap(dirent => {
               const full = `${d}/${dirent.name}`;
               return dirent.isDirectory() ? collectFiles(full) : [full];
             });
-            const prFiles = collectFiles(prDir).filter(f => f.endsWith('.json'));
+            // Only include metrics for files changed in this PR
+            let prFiles = collectFiles(prDir).filter(f => f.endsWith('.json'));
+            prFiles = prFiles.filter(fullPath => {
+              const rel = fullPath.slice(prDir.length + 1).replace(/\.json$/, '');
+              return changedFiles.has(rel);
+            });
             prFiles.forEach(fullPath => {
               const rel = fullPath.slice(prDir.length + 1).replace(/\.json$/, '');
               // Build GitHub link for file

--- a/crates/cribo/src/main.rs
+++ b/crates/cribo/src/main.rs
@@ -87,7 +87,6 @@ fn main() -> anyhow::Result<()> {
         ));
     }
 
-    // Create bundler and run
     let mut bundler = BundleOrchestrator::new(config);
 
     if cli.stdout {


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Updated the GitHub Actions workflow to fetch the list of files changed in the current pull request and filter rust-code-analysis metrics to only comment on those files, making PR feedback more focused and relevant.
- Performed a minor code cleanup in `crates/cribo/src/main.rs` by removing a redundant comment.

This PR enhances the CI workflow by ensuring that rust-code-analysis metrics are only posted for files actually changed in the PR, reducing unnecessary information in PR comments. Additionally, it includes a small code cleanup for improved readability.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lint.yml</strong><dd><code>Restrict rust-code-analysis PR comments to changed files only</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint.yml
<li>Added logic to fetch the list of files changed in the current PR using <br>the GitHub API.<br> <li> Filtered the set of files for which rust-code-analysis metrics are <br>commented to include only those files that were changed in the PR.<br> <li> Ensured that only relevant metrics are posted as PR comments, reducing <br>noise and focusing on changed files.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/132/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2">+12/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Miscellaneous
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Minor code cleanup by removing redundant comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cribo/src/main.rs
<li>Removed a redundant comment about creating and running the bundler for <br>clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/ophidiarium/cribo/pull/132/files#diff-65ea9d7209b347d798c8a1b0b72367f59a9aa45a37ff7f97f823e79cadf246b6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to report code metrics only for files changed in the pull request.
  - Removed a non-functional comment from the application code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->