### PR TITLE
perf(test): fix slow cli_stdout tests by using pre-built binary

### DIFF
--- a/crates/cribo/tests/test_cli_stdout.rs
+++ b/crates/cribo/tests/test_cli_stdout.rs
@@ -13,13 +13,12 @@ fn get_fixture_path(relative_path: &str) -> String {
 
 /// Run cribo with given arguments and return (stdout, stderr, exit_code)
 fn run_cribo(args: &[&str]) -> (String, String, i32) {
-    let output = Command::new("cargo")
-        .args(["run", "--bin", "cribo", "--quiet", "--"])
+    // Use the pre-built binary instead of cargo run for performance
+    let cribo_exe = env!("CARGO_BIN_EXE_cribo");
+
+    let output = Command::new(cribo_exe)
         .args(args)
         .env("RUST_LOG", "off")
-        .env("CARGO_TERM_QUIET", "true")
-        .env("CARGO_TERM_COLOR", "never")
-        .env("RUSTFLAGS", "-Awarnings")
         .output()
         .expect("Failed to execute command");
 


### PR DESCRIPTION
The test_cli_stdout tests were taking 2-3 minutes because they were using `cargo run` which recompiled the entire project on each test run.

Changed to use the pre-built binary via env!("CARGO_BIN_EXE_cribo") macro, which provides the path to the already-compiled binary. This reduces test execution time from 2-3 minutes to ~0.2 seconds.

Also removed unnecessary environment variables that were only needed for cargo run (CARGO_TERM_QUIET, CARGO_TERM_COLOR, RUSTFLAGS).