### PR TITLE
refactor(bundler): move resolve_relative_import_with_context to import_transformer

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -22,7 +22,10 @@ use crate::{
             ProcessGlobalsParams, SemanticContext,
         },
         expression_handlers, import_deduplicator,
-        import_transformer::{RecursiveImportTransformer, RecursiveImportTransformerParams},
+        import_transformer::{
+            RecursiveImportTransformer, RecursiveImportTransformerParams,
+            resolve_relative_import_with_context,
+        },
         module_registry::{INIT_RESULT_VAR, generate_unique_name},
         namespace_manager,
     },
@@ -281,201 +284,6 @@ impl<'a> HybridStaticBundler<'a> {
 
         let mut assigner = NodeIndexAssigner { bundler: self };
         assigner.visit_mod(&ruff_python_ast::Mod::Module(module.clone()));
-    }
-
-    /// Resolve a relative import with context
-    pub fn resolve_relative_import_with_context(
-        &self,
-        import_from: &StmtImportFrom,
-        current_module: &str,
-        module_path: Option<&Path>,
-    ) -> Option<String> {
-        log::debug!(
-            "Resolving relative import: level={}, module={:?}, current_module={}",
-            import_from.level,
-            import_from.module,
-            current_module
-        );
-
-        if import_from.level > 0 {
-            // This is a relative import
-            let mut parts: Vec<&str> = current_module.split('.').collect();
-
-            // Special handling for different module types
-            if parts.len() == 1 && import_from.level == 1 {
-                // For single-component modules with level 1 imports, we need to determine
-                // if this is a root-level module or a package __init__ file
-
-                // Check if current module is a package __init__.py file
-                let is_package_init = if let Some(path) = module_path {
-                    path.file_name()
-                        .and_then(|f| f.to_str())
-                        .map(|f| f == "__init__.py")
-                        .unwrap_or(false)
-                } else {
-                    false
-                };
-
-                // Check if this module is the entry module and is __init__.py
-                let is_entry_init = current_module
-                    == self
-                        .entry_path
-                        .as_ref()
-                        .and_then(|p| Path::new(p).file_stem())
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("")
-                    && is_package_init;
-
-                if is_entry_init {
-                    // This is the entry __init__.py - relative imports should resolve within the
-                    // package but without the package prefix
-                    log::debug!(
-                        "Module '{current_module}' is the entry __init__.py, clearing parts for \
-                         relative import"
-                    );
-                    parts.clear();
-                } else {
-                    // Check if this module is in the inlined_modules or module_registry to
-                    // determine if it's a package
-                    let is_package = self
-                        .bundled_modules
-                        .iter()
-                        .any(|m| m.starts_with(&format!("{current_module}.")));
-
-                    if is_package {
-                        // This is a package __init__ file - level 1 imports stay in the package
-                        log::debug!(
-                            "Module '{current_module}' is a package, keeping parts for relative \
-                             import"
-                        );
-                        // Keep parts as is
-                    } else {
-                        // This is a root-level module - level 1 imports are siblings
-                        log::debug!(
-                            "Module '{current_module}' is root-level, clearing parts for relative \
-                             import"
-                        );
-                        parts.clear();
-                    }
-                }
-            } else {
-                // For modules with multiple components (e.g., "greetings.greeting")
-                // Special handling: if this module represents a package __init__.py file,
-                // the first level doesn't remove anything (stays in the package)
-                // Subsequent levels go up the hierarchy
-
-                // Check if current module is a package __init__.py file
-                let is_package_init = if let Some(path) = module_path {
-                    path.file_name()
-                        .and_then(|f| f.to_str())
-                        .map(|f| f == "__init__.py")
-                        .unwrap_or(false)
-                } else {
-                    // Fallback: check if module has submodules
-                    self.bundled_modules
-                        .iter()
-                        .any(|m| m.starts_with(&format!("{current_module}.")))
-                };
-
-                let levels_to_remove = if is_package_init {
-                    // For package __init__.py files, the first dot stays in the package
-                    // So we remove (level - 1) parts
-                    import_from.level.saturating_sub(1)
-                } else {
-                    // For regular modules, remove 'level' parts
-                    import_from.level
-                };
-
-                log::debug!(
-                    "Relative import resolution: current_module={}, is_package_init={}, level={}, \
-                     levels_to_remove={}, parts={:?}",
-                    current_module,
-                    is_package_init,
-                    import_from.level,
-                    levels_to_remove,
-                    parts
-                );
-
-                for _ in 0..levels_to_remove {
-                    if parts.is_empty() {
-                        log::debug!("Invalid relative import - ran out of parent levels");
-                        return None; // Invalid relative import
-                    }
-                    parts.pop();
-                }
-            }
-
-            // Add the module name if specified
-            if let Some(ref module) = import_from.module {
-                parts.push(module.as_str());
-            }
-
-            let resolved = parts.join(".");
-
-            // Handle the case where relative import resolves to empty or just the package itself
-            // This happens with "from . import something" in a package __init__.py
-            if resolved.is_empty() {
-                // For "from . import X" in a package, the resolved module is the current package
-                // We need to check if we're in a package __init__.py
-                if import_from.level == 1 && import_from.module.is_none() {
-                    // This is "from . import X" - we need to determine the parent package
-                    // For a module like "requests.utils", the parent is "requests"
-                    // For a module like "__init__", it's the current directory
-                    if current_module.contains('.') {
-                        // Module has a parent package - extract it
-                        let parent_parts: Vec<&str> = current_module.split('.').collect();
-                        let parent = parent_parts[..parent_parts.len() - 1].join(".");
-                        log::debug!(
-                            "Relative import 'from . import' in module '{current_module}' - \
-                             returning parent package '{parent}'"
-                        );
-                        return Some(parent);
-                    } else if current_module == "__init__" {
-                        // This is a package __init__.py doing "from . import X"
-                        // The package name should be derived from the directory
-                        log::debug!(
-                            "Relative import 'from . import' in __init__ module - this case needs \
-                             special handling"
-                        );
-                        // For now, we'll return None and let it be handled elsewhere
-                        return None;
-                    } else {
-                        // Single-level module doing "from . import X" - this is importing from the
-                        // same directory We need to return empty string to
-                        // indicate current directory
-                        log::debug!(
-                            "Relative import 'from . import' in root-level module \
-                             '{current_module}' - returning empty for current directory"
-                        );
-                        return Some(String::new());
-                    }
-                }
-                log::debug!("Invalid relative import - resolved to empty module");
-                return None;
-            }
-
-            // Check for potential circular import
-            if resolved == current_module {
-                log::warn!("Potential circular import detected: {current_module} importing itself");
-            }
-
-            log::debug!("Resolved relative import to: {resolved}");
-            Some(resolved)
-        } else {
-            // Not a relative import
-            let resolved = import_from.module.as_ref().map(|m| m.as_str().to_string());
-            log::debug!("Not a relative import, resolved to: {resolved:?}");
-            resolved
-        }
-    }
-
-    /// Resolve relative import
-    pub fn resolve_relative_import(
-        &self,
-        import_from: &StmtImportFrom,
-        current_module: &str,
-    ) -> Option<String> {
-        self.resolve_relative_import_with_context(import_from, current_module, None)
     }
 
     /// Filter exports based on tree shaking
@@ -2751,7 +2559,13 @@ impl<'a> HybridStaticBundler<'a> {
                                 // Handle relative imports
                                 let resolved_module = if import_from.level > 0 {
                                     // Resolve relative import to absolute
-                                    self.resolve_relative_import(import_from, module_name)
+                                    resolve_relative_import_with_context(
+                                        import_from,
+                                        module_name,
+                                        None,
+                                        self.entry_path.as_deref(),
+                                        &self.bundled_modules,
+                                    )
                                 } else {
                                     import_from.module.as_ref().map(|m| m.as_str().to_string())
                                 };
@@ -2821,10 +2635,12 @@ impl<'a> HybridStaticBundler<'a> {
                     // Resolve relative imports to absolute module names
                     let resolved_module = if import_from.level > 0 {
                         // This is a relative import, resolve it
-                        self.resolve_relative_import_with_context(
+                        resolve_relative_import_with_context(
                             import_from,
                             module_name,
                             Some(module_path),
+                            self.entry_path.as_deref(),
+                            &self.bundled_modules,
                         )
                     } else {
                         // Absolute import
@@ -7670,8 +7486,13 @@ impl<'a> HybridStaticBundler<'a> {
                             // Check if this symbol is imported from an inlined submodule
                             for stmt in &ast.body {
                                 if let Stmt::ImportFrom(import_from) = stmt {
-                                    let resolved_module =
-                                        self.resolve_relative_import(import_from, module_name);
+                                    let resolved_module = resolve_relative_import_with_context(
+                                        import_from,
+                                        module_name,
+                                        None,
+                                        self.entry_path.as_deref(),
+                                        &self.bundled_modules,
+                                    );
                                     if let Some(ref resolved) = resolved_module {
                                         // Check if the resolved module is inlined
                                         if self.inlined_modules.contains(resolved) {

--- a/crates/cribo/src/code_generator/further-split-misses.md
+++ b/crates/cribo/src/code_generator/further-split-misses.md
@@ -1,0 +1,45 @@
+# Analysis of bundler.rs Refactoring Misses
+
+This document outlines the discrepancies between the proposed refactoring in `further-split.md` and the current state of `crates/cribo/src/code_generator/bundler.rs`.
+
+## 1. Functions Not Yet Extracted
+
+The following functions were identified as candidates for extraction in `further-split.md` but remain fully implemented in `bundler.rs`. They are sorted by their approximate line count (from largest to smallest).
+
+- `rewrite_import_from` (~150 lines)
+- `rewrite_import_with_renames` (~150 lines)
+- `resolve_relative_import_with_context` (~100 lines)
+- `transform_namespace_package_imports` (~80 lines)
+- `collect_module_renames` (~80 lines)
+- `create_namespace_for_inlined_module_static` (~80 lines)
+- `ensure_namespace_exists` (~50 lines)
+- `extract_all_exports` (~50 lines)
+- `handle_imports_from_inlined_module_with_context` (~50 lines)
+- `add_hoisted_imports` (~50 lines)
+- `collect_imports_from_module` (~40 lines)
+- `sort_wrapper_modules_by_dependencies` (~25 lines)
+- `transform_module_to_cache_init_function` (~20 lines)
+- `process_wrapper_module_globals` (~20 lines)
+- `is_package_init_reexport` (~20 lines)
+- `create_namespace_with_name` (~15 lines)
+- `collect_future_imports_from_ast` (~15 lines)
+- `create_namespace_statements` (~15 lines)
+- `create_namespace_attribute` (~15 lines)
+- `sort_wrapped_modules_by_dependencies` (~10 lines)
+- `filter_exports_by_tree_shaking` (~10 lines)
+- `should_inline_symbol` (~10 lines)
+
+## 2. Functions Using Wrappers Instead of Direct Calls
+
+The following functions were moved out of `bundler.rs`, but the bundler still contains a local wrapper function to call the moved implementation instead of using a direct `submodule::function()` call.
+
+- `rewrite_aliases_in_stmt`: Wraps a call to `rewrite_aliases_in_stmt_impl`.
+- `rewrite_aliases_in_expr`: Wraps a call to `rewrite_aliases_in_expr_impl`.
+- `resolve_import_aliases_in_stmt`: Wraps a call to `expression_handlers::resolve_import_aliases_in_stmt`.
+
+### Partially Refactored Wrappers
+
+These functions are wrappers around other functions that are *also* still present in `bundler.rs`, indicating an incomplete refactoring step.
+
+- `resolve_relative_import`: Wraps `resolve_relative_import_with_context`.
+- `handle_imports_from_inlined_module`: Wraps `handle_imports_from_inlined_module_with_context`.

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -2058,9 +2058,9 @@ pub fn resolve_relative_import_with_context(
             // Check if this module is the entry module and is __init__.py
             let is_entry_init = current_module
                 == entry_path
-                    .as_ref()
-                    .and_then(|p| Path::new(p).file_stem())
-                    .and_then(|s| s.to_str())
+                    .map(Path::new)
+                    .and_then(Path::file_stem)
+                    .and_then(std::ffi::OsStr::to_str)
                     .unwrap_or("")
                 && is_package_init;
 

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -526,23 +526,13 @@ impl<'a> RecursiveImportTransformer<'a> {
                     }
 
                     // Resolve relative imports first
-                    let resolved_module = if let Some(module_path) = self.module_path {
-                        resolve_relative_import_with_context(
-                            import_from,
-                            self.module_name,
-                            Some(module_path),
-                            self.bundler.entry_path.as_deref(),
-                            &self.bundler.bundled_modules,
-                        )
-                    } else {
-                        resolve_relative_import_with_context(
-                            import_from,
-                            self.module_name,
-                            None,
-                            self.bundler.entry_path.as_deref(),
-                            &self.bundler.bundled_modules,
-                        )
-                    };
+                    let resolved_module = resolve_relative_import_with_context(
+                        import_from,
+                        self.module_name,
+                        self.module_path,
+                        self.bundler.entry_path.as_deref(),
+                        &self.bundler.bundled_modules,
+                    );
 
                     if let Some(resolved) = &resolved_module {
                         // Track aliases for imported symbols (non-importlib)
@@ -623,23 +613,13 @@ impl<'a> RecursiveImportTransformer<'a> {
         );
 
         // Resolve relative imports
-        let resolved_module = if let Some(module_path) = self.module_path {
-            resolve_relative_import_with_context(
-                import_from,
-                self.module_name,
-                Some(module_path),
-                self.bundler.entry_path.as_deref(),
-                &self.bundler.bundled_modules,
-            )
-        } else {
-            resolve_relative_import_with_context(
-                import_from,
-                self.module_name,
-                None,
-                self.bundler.entry_path.as_deref(),
-                &self.bundler.bundled_modules,
-            )
-        };
+        let resolved_module = resolve_relative_import_with_context(
+            import_from,
+            self.module_name,
+            self.module_path,
+            self.bundler.entry_path.as_deref(),
+            &self.bundler.bundled_modules,
+        );
 
         log::debug!(
             "handle_import_from: resolved_module={:?}, is_wrapper_init={}, current_module={}",

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -527,14 +527,21 @@ impl<'a> RecursiveImportTransformer<'a> {
 
                     // Resolve relative imports first
                     let resolved_module = if let Some(module_path) = self.module_path {
-                        self.bundler.resolve_relative_import_with_context(
+                        resolve_relative_import_with_context(
                             import_from,
                             self.module_name,
                             Some(module_path),
+                            self.bundler.entry_path.as_deref(),
+                            &self.bundler.bundled_modules,
                         )
                     } else {
-                        self.bundler
-                            .resolve_relative_import(import_from, self.module_name)
+                        resolve_relative_import_with_context(
+                            import_from,
+                            self.module_name,
+                            None,
+                            self.bundler.entry_path.as_deref(),
+                            &self.bundler.bundled_modules,
+                        )
                     };
 
                     if let Some(resolved) = &resolved_module {
@@ -617,14 +624,21 @@ impl<'a> RecursiveImportTransformer<'a> {
 
         // Resolve relative imports
         let resolved_module = if let Some(module_path) = self.module_path {
-            self.bundler.resolve_relative_import_with_context(
+            resolve_relative_import_with_context(
                 import_from,
                 self.module_name,
                 Some(module_path),
+                self.bundler.entry_path.as_deref(),
+                &self.bundler.bundled_modules,
             )
         } else {
-            self.bundler
-                .resolve_relative_import(import_from, self.module_name)
+            resolve_relative_import_with_context(
+                import_from,
+                self.module_name,
+                None,
+                self.bundler.entry_path.as_deref(),
+                &self.bundler.bundled_modules,
+            )
         };
 
         log::debug!(
@@ -1886,7 +1900,13 @@ fn rewrite_import_from(
         import_from.module.as_ref().map(|m| m.as_str()),
         current_module
     );
-    let resolved_module_name = bundler.resolve_relative_import(&import_from, current_module);
+    let resolved_module_name = resolve_relative_import_with_context(
+        &import_from,
+        current_module,
+        None,
+        bundler.entry_path.as_deref(),
+        &bundler.bundled_modules,
+    );
 
     let Some(module_name) = resolved_module_name else {
         // If we can't resolve the module, return the original import
@@ -2005,5 +2025,202 @@ fn rewrite_import_from(
                 bundler.create_namespace_with_name(local_name, full_module_path)
             },
         )
+    }
+}
+
+/// Resolve a relative import with context
+///
+/// This function resolves relative imports (e.g., `from . import foo` or `from ..bar import baz`)
+/// to absolute module names based on the current module and its file path.
+///
+/// # Arguments
+/// * `import_from` - The import statement to resolve
+/// * `current_module` - The name of the module containing the import
+/// * `module_path` - Optional path to the module file (used to detect __init__.py)
+/// * `entry_path` - Optional entry point path for the bundle
+/// * `bundled_modules` - Set of all bundled module names
+///
+/// # Returns
+/// The resolved absolute module name, or None if the import cannot be resolved
+pub fn resolve_relative_import_with_context(
+    import_from: &StmtImportFrom,
+    current_module: &str,
+    module_path: Option<&Path>,
+    entry_path: Option<&str>,
+    bundled_modules: &FxIndexSet<String>,
+) -> Option<String> {
+    log::debug!(
+        "Resolving relative import: level={}, module={:?}, current_module={}",
+        import_from.level,
+        import_from.module,
+        current_module
+    );
+
+    if import_from.level > 0 {
+        // This is a relative import
+        let mut parts: Vec<&str> = current_module.split('.').collect();
+
+        // Special handling for different module types
+        if parts.len() == 1 && import_from.level == 1 {
+            // For single-component modules with level 1 imports, we need to determine
+            // if this is a root-level module or a package __init__ file
+
+            // Check if current module is a package __init__.py file
+            let is_package_init = if let Some(path) = module_path {
+                path.file_name()
+                    .and_then(|f| f.to_str())
+                    .map(|f| f == "__init__.py")
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+
+            // Check if this module is the entry module and is __init__.py
+            let is_entry_init = current_module
+                == entry_path
+                    .as_ref()
+                    .and_then(|p| Path::new(p).file_stem())
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                && is_package_init;
+
+            if is_entry_init {
+                // This is the entry __init__.py - relative imports should resolve within the
+                // package but without the package prefix
+                log::debug!(
+                    "Module '{current_module}' is the entry __init__.py, clearing parts for \
+                     relative import"
+                );
+                parts.clear();
+            } else {
+                // Check if this module is in the bundled_modules to
+                // determine if it's a package
+                let is_package = bundled_modules
+                    .iter()
+                    .any(|m| m.starts_with(&format!("{current_module}.")));
+
+                if is_package {
+                    // This is a package __init__ file - level 1 imports stay in the package
+                    log::debug!(
+                        "Module '{current_module}' is a package, keeping parts for relative import"
+                    );
+                    // Keep parts as is
+                } else {
+                    // This is a root-level module - level 1 imports are siblings
+                    log::debug!(
+                        "Module '{current_module}' is root-level, clearing parts for relative \
+                         import"
+                    );
+                    parts.clear();
+                }
+            }
+        } else {
+            // For modules with multiple components (e.g., "greetings.greeting")
+            // Special handling: if this module represents a package __init__.py file,
+            // the first level doesn't remove anything (stays in the package)
+            // Subsequent levels go up the hierarchy
+
+            // Check if current module is a package __init__.py file
+            let is_package_init = if let Some(path) = module_path {
+                path.file_name()
+                    .and_then(|f| f.to_str())
+                    .map(|f| f == "__init__.py")
+                    .unwrap_or(false)
+            } else {
+                // Fallback: check if module has submodules
+                bundled_modules
+                    .iter()
+                    .any(|m| m.starts_with(&format!("{current_module}.")))
+            };
+
+            let levels_to_remove = if is_package_init {
+                // For package __init__.py files, the first dot stays in the package
+                // So we remove (level - 1) parts
+                import_from.level.saturating_sub(1)
+            } else {
+                // For regular modules, remove 'level' parts
+                import_from.level
+            };
+
+            log::debug!(
+                "Relative import resolution: current_module={}, is_package_init={}, level={}, \
+                 levels_to_remove={}, parts={:?}",
+                current_module,
+                is_package_init,
+                import_from.level,
+                levels_to_remove,
+                parts
+            );
+
+            for _ in 0..levels_to_remove {
+                if parts.is_empty() {
+                    log::debug!("Invalid relative import - ran out of parent levels");
+                    return None; // Invalid relative import
+                }
+                parts.pop();
+            }
+        }
+
+        // Add the module name if specified
+        if let Some(ref module) = import_from.module {
+            parts.push(module.as_str());
+        }
+
+        let resolved = parts.join(".");
+
+        // Handle the case where relative import resolves to empty or just the package itself
+        // This happens with "from . import something" in a package __init__.py
+        if resolved.is_empty() {
+            // For "from . import X" in a package, the resolved module is the current package
+            // We need to check if we're in a package __init__.py
+            if import_from.level == 1 && import_from.module.is_none() {
+                // This is "from . import X" - we need to determine the parent package
+                // For a module like "requests.utils", the parent is "requests"
+                // For a module like "__init__", it's the current directory
+                if current_module.contains('.') {
+                    // Module has a parent package - extract it
+                    let parent_parts: Vec<&str> = current_module.split('.').collect();
+                    let parent = parent_parts[..parent_parts.len() - 1].join(".");
+                    log::debug!(
+                        "Relative import 'from . import' in module '{current_module}' - returning \
+                         parent package '{parent}'"
+                    );
+                    return Some(parent);
+                } else if current_module == "__init__" {
+                    // This is a package __init__.py doing "from . import X"
+                    // The package name should be derived from the directory
+                    log::debug!(
+                        "Relative import 'from . import' in __init__ module - this case needs \
+                         special handling"
+                    );
+                    // For now, we'll return None and let it be handled elsewhere
+                    return None;
+                } else {
+                    // Single-level module doing "from . import X" - this is importing from the
+                    // same directory We need to return empty string to
+                    // indicate current directory
+                    log::debug!(
+                        "Relative import 'from . import' in root-level module '{current_module}' \
+                         - returning empty for current directory"
+                    );
+                    return Some(String::new());
+                }
+            }
+            log::debug!("Invalid relative import - resolved to empty module");
+            return None;
+        }
+
+        // Check for potential circular import
+        if resolved == current_module {
+            log::warn!("Potential circular import detected: {current_module} importing itself");
+        }
+
+        log::debug!("Resolved relative import to: {resolved}");
+        Some(resolved)
+    } else {
+        // Not a relative import
+        let resolved = import_from.module.as_ref().map(|m| m.as_str().to_string());
+        log::debug!("Not a relative import, resolved to: {resolved:?}");
+        resolved
     }
 }

--- a/crates/cribo/src/code_generator/module_transformer.rs
+++ b/crates/cribo/src/code_generator/module_transformer.rs
@@ -26,7 +26,10 @@ use crate::{
         context::ModuleTransformContext,
         globals::{GlobalsLifter, transform_globals_in_stmt},
         import_deduplicator,
-        import_transformer::{RecursiveImportTransformer, RecursiveImportTransformerParams},
+        import_transformer::{
+            RecursiveImportTransformer, RecursiveImportTransformerParams,
+            resolve_relative_import_with_context,
+        },
     },
     types::{FxIndexMap, FxIndexSet},
 };
@@ -80,10 +83,12 @@ pub fn transform_module_to_init_function<'a>(
     for stmt in &ast.body {
         if let Stmt::ImportFrom(import_from) = stmt {
             // Resolve the module to check if it's inlined
-            let resolved_module = bundler.resolve_relative_import_with_context(
+            let resolved_module = resolve_relative_import_with_context(
                 import_from,
                 ctx.module_name,
                 Some(ctx.module_path),
+                bundler.entry_path.as_deref(),
+                &bundler.bundled_modules,
             );
 
             if let Some(ref module) = resolved_module {

--- a/crates/cribo/src/code_generator/module_transformer.rs
+++ b/crates/cribo/src/code_generator/module_transformer.rs
@@ -80,6 +80,9 @@ pub fn transform_module_to_init_function<'a>(
 
     // Track imports from inlined modules before transformation
     let mut imports_from_inlined = Vec::new();
+    let entry_path = bundler.entry_path.as_deref();
+    let bundled_modules = &bundler.bundled_modules;
+
     for stmt in &ast.body {
         if let Stmt::ImportFrom(import_from) = stmt {
             // Resolve the module to check if it's inlined
@@ -87,8 +90,8 @@ pub fn transform_module_to_init_function<'a>(
                 import_from,
                 ctx.module_name,
                 Some(ctx.module_path),
-                bundler.entry_path.as_deref(),
-                &bundler.bundled_modules,
+                entry_path,
+                bundled_modules,
             );
 
             if let Some(ref module) = resolved_module {


### PR DESCRIPTION
## Summary

This PR refactors the `resolve_relative_import_with_context` function by moving it from `bundler.rs` to `import_transformer.rs` as part of the effort to split `bundler.rs` into smaller, more manageable modules.

## Changes

- Moved `resolve_relative_import_with_context` from `bundler.rs` to `import_transformer.rs` as a standalone function
- Removed the wrapper function `resolve_relative_import` from `bundler.rs`
- Updated all 7 call sites to use the function directly from the `import_transformer` module
- The function now takes `entry_path` and `bundled_modules` as parameters instead of accessing them through `self`

## Test Results

All tests pass successfully:
```
cargo test --workspace
cargo clippy --workspace --all-targets
```

This refactoring maintains identical functionality while improving code organization and reducing the size of `bundler.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the handling of relative imports by consolidating complex logic into a single standalone function, improving maintainability and clarity.
  * Updated all relevant components to use the new import resolution function, ensuring consistent behavior across the application.

* **Documentation**
  * Added a new document analyzing the current state and progress of the ongoing refactoring, providing transparency on outstanding tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->