### PR TITLE
fix: handle submodules in __all__ exports correctly

### DIFF
--- a/crates/cribo/src/code_generator/module_transformer.rs
+++ b/crates/cribo/src/code_generator/module_transformer.rs
@@ -360,8 +360,8 @@ pub fn transform_module_to_init_function<'a>(
                             // This was imported from an inlined module
                             // Use a special case: if no scope info available, include imported
                             // symbols
-                            let should_include = module_scope_symbols
-                                .is_none_or(|symbols| symbols.contains(&name));
+                            let should_include =
+                                module_scope_symbols.is_none_or(|symbols| symbols.contains(&name));
 
                             if should_include {
                                 debug!("Exporting imported symbol '{name}' as module attribute");
@@ -1459,13 +1459,12 @@ fn add_module_attr_if_exported(
     module_scope_symbols: Option<&rustc_hash::FxHashSet<String>>,
 ) {
     if let Some(name) = bundler.extract_simple_assign_target(assign)
-        && should_include_symbol(bundler, &name, module_name, module_scope_symbols) {
-            body.push(
-                crate::code_generator::module_registry::create_module_attr_assignment(
-                    "module", &name,
-                ),
-            );
-        }
+        && should_include_symbol(bundler, &name, module_name, module_scope_symbols)
+    {
+        body.push(
+            crate::code_generator::module_registry::create_module_attr_assignment("module", &name),
+        );
+    }
 }
 
 /// Create namespace for inlined submodule

--- a/crates/cribo/tests/snapshots/bundled_code@namespace_attribute_reference.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@namespace_attribute_reference.snap
@@ -15,7 +15,7 @@ class MyError(Exception):
     """Base exception class"""
     pass
 @functools.cache
-def __cribo_init___cribo_fd0209_mypkg_compat():
+def __cribo_init___cribo_19d82f_mypkg_compat():
     module = types.SimpleNamespace()
     module.__name__ = 'mypkg.compat'
     try:
@@ -33,7 +33,7 @@ def __cribo_init___cribo_fd0209_mypkg_compat():
     basestring = str
     module.basestring = basestring
     return module
-mypkg.compat = __cribo_init___cribo_fd0209_mypkg_compat()
+mypkg.compat = __cribo_init___cribo_19d82f_mypkg_compat()
 class MyJSONError(MyError, mypkg.compat.JSONDecodeError):
     """JSON error that inherits from compat JSONDecodeError"""
 
@@ -42,7 +42,6 @@ class MyJSONError(MyError, mypkg.compat.JSONDecodeError):
         MyError.__init__(self, str(args[0]) if args else "")
 MyError.__module__ = 'mypkg.exceptions'
 MyJSONError.__module__ = 'mypkg.exceptions'
-mypkg.compat = __cribo_init___cribo_fd0209_mypkg_compat()
 exceptions = types.SimpleNamespace()
 exceptions.MyError = MyError
 exceptions.MyJSONError = MyJSONError


### PR DESCRIPTION
## Summary
- Fixed the failing `namespace_attribute_reference` test by properly handling submodules in `__all__` exports
- Prevents invalid assignments like `mypkg.compat = compat` when submodules are exported
- Enables proper inheritance from namespace attributes (e.g., `MyJSONError` inheriting from `mypkg.compat.JSONDecodeError`)

## Changes
1. **Added submodule check in `collect_module_renames`**: Skip submodules when processing exports from `__all__` to prevent them from being treated as symbols
2. **Re-enabled forward reference detection**: The `has_cross_module_inheritance_forward_refs` method now properly detects when classes inherit from namespace attributes  
3. **Added function deduplication**: Implemented `deduplicate_function_definitions` to remove duplicate init functions that were being generated
4. **Improved namespace initialization tracking**: Better tracking of namespace init functions and their positions to ensure proper ordering

## Test Results
- The `namespace_attribute_reference` test now passes correctly
- All tests pass successfully (`cargo test --workspace`)
- Clippy shows only minor warnings about unused functions and code style
- 6 snapshot updates: 4 new snapshots for the fixed test, 2 modified snapshots with reordered statements (functionality unchanged)

## Test plan
- [x] Run the specific failing test: `INSTA_GLOB_FILTER="**/namespace_attribute_reference/main.py" cargo nextest run --test test_bundling_snapshots`
- [x] Run full test suite: `cargo test --workspace`
- [x] Run clippy: `cargo clippy --workspace --all-targets`
- [x] Verify bundled code executes correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deduplication of namespace initialization assignments to prevent duplicates.
  * Improved clarity and consistency in handling forward references related to namespace initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->