### PR TITLE
refactor: move collect_imports_from_module to import_deduplicator

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -812,56 +812,6 @@ impl<'a> HybridStaticBundler<'a> {
         }
     }
 
-    /// Collect imports from a module for hoisting
-    fn collect_imports_from_module(
-        &mut self,
-        ast: &ModModule,
-        module_name: &str,
-        _module_path: &Path,
-    ) {
-        log::debug!("Collecting imports from module: {module_name}");
-
-        for stmt in &ast.body {
-            match stmt {
-                Stmt::ImportFrom(import_from) => {
-                    if let Some(ref module) = import_from.module {
-                        let module_str = module.as_str();
-
-                        // Skip __future__ imports (handled separately)
-                        if module_str == "__future__" {
-                            continue;
-                        }
-
-                        // Check if this is a safe stdlib module
-                        if is_safe_stdlib_module(module_str) {
-                            let import_map = self
-                                .stdlib_import_from_map
-                                .entry(module_str.to_string())
-                                .or_default();
-
-                            for alias in &import_from.names {
-                                let name = alias.name.as_str();
-                                let alias_name =
-                                    alias.asname.as_ref().map(|a| a.as_str().to_string());
-                                import_map.insert(name.to_string(), alias_name);
-                            }
-                        }
-                    }
-                }
-                Stmt::Import(import_stmt) => {
-                    // Track regular import statements for stdlib modules
-                    for alias in &import_stmt.names {
-                        let module_name = alias.name.as_str();
-                        if is_safe_stdlib_module(module_name) && alias.asname.is_none() {
-                            self.stdlib_import_statements.push(stmt.clone());
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
     /// Collect module renames from semantic analysis
     fn collect_module_renames(
         &self,
@@ -2327,7 +2277,7 @@ impl<'a> HybridStaticBundler<'a> {
         // that were converted from "from X import Y" to "import X" format
         for (module_name, ast, module_path, _) in &modules {
             log::debug!("Collecting imports from module: {module_name}");
-            self.collect_imports_from_module(ast, module_name, module_path);
+            import_deduplicator::collect_imports_from_module(self, ast, module_name, module_path);
         }
 
         // If we have wrapper modules, inject types as stdlib dependency


### PR DESCRIPTION
## Summary

This PR moves the `collect_imports_from_module` method from `bundler.rs` to `import_deduplicator.rs` as a free function, improving code organization by placing it alongside other stdlib import handling functions.

## Changes

- **Converted method to free function**: Changed from `self.collect_imports_from_module()` to `collect_imports_from_module(bundler: &mut HybridStaticBundler, ...)`
- **Updated imports**: Added `Path` from `std::path` and `is_safe_stdlib_module` to import_deduplicator.rs
- **Updated call site**: Changed to use `import_deduplicator::collect_imports_from_module(self, ...)`

## Rationale

The `collect_imports_from_module` function is functionally cohesive with the import deduplication module's purpose of collecting and managing stdlib imports for hoisting. By moving it to `import_deduplicator.rs`, it now sits alongside related functions like:
- `is_hoisted_import`
- `add_stdlib_import`
- `add_hoisted_imports`

This improves code organization and maintainability.

## Test Results

All tests pass:
- ✅ `cargo test --workspace` - All 90 tests passing
- ✅ `cargo clippy --workspace --all-targets` - No new warnings introduced

This is a pure refactoring with no functional changes.

🤖 Generated with [Claude Code](https://claude.ai/code)