### PR TITLE
refactor: fix import deduplication by moving duplicate checking logic

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -3977,13 +3977,13 @@ impl<'a> Bundler<'a> {
 
                 match stmt {
                     Stmt::ImportFrom(import_from) => {
-                        let is_duplicate = import_deduplicator::is_duplicate_import_from(
+                        let duplicate = import_deduplicator::is_duplicate_import_from(
                             self,
                             import_from,
                             &final_body,
                         );
 
-                        if !is_duplicate {
+                        if !duplicate {
                             // Imports have already been transformed by RecursiveImportTransformer
                             final_body.push(stmt.clone());
                         } else {
@@ -3994,13 +3994,13 @@ impl<'a> Bundler<'a> {
                         }
                     }
                     Stmt::Import(import_stmt) => {
-                        let is_duplicate = import_deduplicator::is_duplicate_import(
+                        let duplicate = import_deduplicator::is_duplicate_import(
                             self,
                             import_stmt,
                             &final_body,
                         );
 
-                        if !is_duplicate {
+                        if !duplicate {
                             // Imports have already been transformed by RecursiveImportTransformer
                             final_body.push(stmt.clone());
                         } else {

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1328,84 +1328,6 @@ impl<'a> Bundler<'a> {
         imported_modules
     }
 
-    /// Check if import from is duplicate
-    fn is_duplicate_import_from(
-        &self,
-        import_from: &StmtImportFrom,
-        existing_body: &[Stmt],
-    ) -> bool {
-        if let Some(ref module) = import_from.module {
-            let module_name = module.as_str();
-            // For third-party imports, check if they're already in the body
-            if !is_safe_stdlib_module(module_name)
-                && !self.is_bundled_module_or_package(module_name)
-            {
-                return existing_body.iter().any(|existing| {
-                    if let Stmt::ImportFrom(existing_import) = existing {
-                        existing_import.module.as_ref().map(|m| m.as_str()) == Some(module_name)
-                            && Self::import_names_match(&import_from.names, &existing_import.names)
-                    } else {
-                        false
-                    }
-                });
-            }
-        }
-        false
-    }
-
-    /// Check if import is duplicate
-    fn is_duplicate_import(&self, import_stmt: &StmtImport, existing_body: &[Stmt]) -> bool {
-        import_stmt.names.iter().any(|alias| {
-            let module_name = alias.name.as_str();
-            // For third-party imports, check if they're already in the body
-            if !is_safe_stdlib_module(module_name)
-                && !self.is_bundled_module_or_package(module_name)
-            {
-                existing_body.iter().any(|existing| {
-                    if let Stmt::Import(existing_import) = existing {
-                        existing_import.names.iter().any(|existing_alias| {
-                            existing_alias.name == alias.name
-                                && existing_alias.asname == alias.asname
-                        })
-                    } else {
-                        false
-                    }
-                })
-            } else {
-                false
-            }
-        })
-    }
-
-    /// Check if two import name lists match
-    fn import_names_match(names1: &[Alias], names2: &[Alias]) -> bool {
-        if names1.len() != names2.len() {
-            return false;
-        }
-
-        // Check if all names match (order doesn't matter)
-        names1.iter().all(|n1| {
-            names2
-                .iter()
-                .any(|n2| n1.name == n2.name && n1.asname == n2.asname)
-        })
-    }
-
-    /// Check if a module is bundled or is a package containing bundled modules
-    fn is_bundled_module_or_package(&self, module_name: &str) -> bool {
-        // Direct check
-        if self.bundled_modules.contains(module_name) {
-            return true;
-        }
-
-        // Check if it's a package containing bundled modules
-        // e.g., if "greetings.greeting" is bundled, then "greetings" is a package
-        let package_prefix = format!("{module_name}.");
-        self.bundled_modules
-            .iter()
-            .any(|bundled| bundled.starts_with(&package_prefix))
-    }
-
     /// Sort deferred imports to ensure dependencies are satisfied
     /// This ensures namespace creations come before assignments that use those namespaces
     /// Uses a simple categorization approach to group statements by type
@@ -4055,7 +3977,11 @@ impl<'a> Bundler<'a> {
 
                 match stmt {
                     Stmt::ImportFrom(import_from) => {
-                        let is_duplicate = self.is_duplicate_import_from(import_from, &final_body);
+                        let is_duplicate = import_deduplicator::is_duplicate_import_from(
+                            self,
+                            import_from,
+                            &final_body,
+                        );
 
                         if !is_duplicate {
                             // Imports have already been transformed by RecursiveImportTransformer
@@ -4068,7 +3994,11 @@ impl<'a> Bundler<'a> {
                         }
                     }
                     Stmt::Import(import_stmt) => {
-                        let is_duplicate = self.is_duplicate_import(import_stmt, &final_body);
+                        let is_duplicate = import_deduplicator::is_duplicate_import(
+                            self,
+                            import_stmt,
+                            &final_body,
+                        );
 
                         if !is_duplicate {
                             // Imports have already been transformed by RecursiveImportTransformer

--- a/crates/cribo/src/code_generator/import_deduplicator.rs
+++ b/crates/cribo/src/code_generator/import_deduplicator.rs
@@ -547,25 +547,50 @@ pub(super) fn deduplicate_deferred_imports_with_existing(
 
 /// Check if an import from statement is a duplicate
 pub(super) fn is_duplicate_import_from(
+    bundler: &Bundler,
     import_from: &StmtImportFrom,
     existing_body: &[Stmt],
 ) -> bool {
-    existing_body.iter().any(|stmt| {
-        if let Stmt::ImportFrom(existing_import) = stmt {
-            existing_import.module == import_from.module
-                && existing_import.level == import_from.level
-                && import_names_match(&existing_import.names, &import_from.names)
-        } else {
-            false
+    if let Some(ref module) = import_from.module {
+        let module_name = module.as_str();
+        // For third-party imports, check if they're already in the body
+        if !is_safe_stdlib_module(module_name)
+            && !is_bundled_module_or_package(bundler, module_name)
+        {
+            return existing_body.iter().any(|existing| {
+                if let Stmt::ImportFrom(existing_import) = existing {
+                    existing_import.module.as_ref().map(|m| m.as_str()) == Some(module_name)
+                        && import_names_match(&import_from.names, &existing_import.names)
+                } else {
+                    false
+                }
+            });
         }
-    })
+    }
+    false
 }
 
 /// Check if an import statement is a duplicate
-pub(super) fn is_duplicate_import(import_stmt: &StmtImport, existing_body: &[Stmt]) -> bool {
-    existing_body.iter().any(|stmt| {
-        if let Stmt::Import(existing_import) = stmt {
-            import_names_match(&existing_import.names, &import_stmt.names)
+pub(super) fn is_duplicate_import(
+    bundler: &Bundler,
+    import_stmt: &StmtImport,
+    existing_body: &[Stmt],
+) -> bool {
+    import_stmt.names.iter().any(|alias| {
+        let module_name = alias.name.as_str();
+        // For third-party imports, check if they're already in the body
+        if !is_safe_stdlib_module(module_name)
+            && !is_bundled_module_or_package(bundler, module_name)
+        {
+            existing_body.iter().any(|existing| {
+                if let Stmt::Import(existing_import) = existing {
+                    existing_import.names.iter().any(|existing_alias| {
+                        existing_alias.name == alias.name && existing_alias.asname == alias.asname
+                    })
+                } else {
+                    false
+                }
+            })
         } else {
             false
         }
@@ -577,35 +602,27 @@ pub(super) fn import_names_match(names1: &[Alias], names2: &[Alias]) -> bool {
     if names1.len() != names2.len() {
         return false;
     }
-
-    names1.iter().all(|alias1| {
+    // Check if all names match (order doesn't matter)
+    names1.iter().all(|n1| {
         names2
             .iter()
-            .any(|alias2| alias1.name == alias2.name && alias1.asname == alias2.asname)
+            .any(|n2| n1.name == n2.name && n1.asname == n2.asname)
     })
 }
 
-/// Collect unique imports from a list of statements
-pub(super) fn collect_unique_imports(statements: &[Stmt]) -> FxIndexSet<String> {
-    let mut imports = FxIndexSet::default();
-
-    for stmt in statements {
-        match stmt {
-            Stmt::Import(import_stmt) => {
-                for alias in &import_stmt.names {
-                    imports.insert(alias.name.to_string());
-                }
-            }
-            Stmt::ImportFrom(import_from_stmt) => {
-                if let Some(ref module) = import_from_stmt.module {
-                    imports.insert(module.to_string());
-                }
-            }
-            _ => {}
-        }
+/// Check if a module is bundled or is a package containing bundled modules
+pub(super) fn is_bundled_module_or_package(bundler: &Bundler, module_name: &str) -> bool {
+    // Direct check
+    if bundler.bundled_modules.contains(module_name) {
+        return true;
     }
-
-    imports
+    // Check if it's a package containing bundled modules
+    // e.g., if "greetings.greeting" is bundled, then "greetings" is a package
+    let package_prefix = format!("{module_name}.");
+    bundler
+        .bundled_modules
+        .iter()
+        .any(|bundled| bundled.starts_with(&package_prefix))
 }
 
 /// Trim unused imports from modules using dependency graph analysis


### PR DESCRIPTION
## Summary

This PR fixes the incomplete refactoring of import deduplication functions by replacing placeholder implementations with the actual logic from bundler.rs.

## Problem

The functions in `import_deduplicator.rs` were placeholder implementations that didn't match the original functionality in `bundler.rs`, resulting in duplicated and potentially inconsistent code.

## Changes

- **Fixed function implementations**:
  - `is_duplicate_import_from()` - Now properly checks for third-party imports with bundled module validation
  - `is_duplicate_import()` - Now properly handles aliases and third-party modules
  - `import_names_match()` - Updated with clearer implementation and comments

- **Moved helper function**:
  - `is_bundled_module_or_package()` - Moved from bundler.rs to import_deduplicator.rs where it belongs

- **Updated callsites**:
  - All calls in bundler.rs now use `import_deduplicator::` module functions

- **Removed duplicate code**:
  - Deleted all duplicate functions from bundler.rs
  - Removed unused `collect_unique_imports()` function from import_deduplicator.rs

## Test Results

✅ All tests pass
✅ No clippy errors (only warnings about nested blocks and unused functions unrelated to this change)
✅ No unused imports in import_deduplicator.rs

This completes the consolidation of import handling logic into the import_deduplicator module, improving code organization and eliminating duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and improved duplicate import detection to exclude bundled modules and packages, enhancing module bundling accuracy.

* **Bug Fixes**
  * Fixed duplicate import checks to correctly handle third-party, bundled, and standard library modules, preventing incorrect duplicate markings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->