### PR TITLE
refactor: consolidate filter_exports_by_tree_shaking functions

### DIFF
--- a/crates/cribo/src/analyzers/symbol_analyzer.rs
+++ b/crates/cribo/src/analyzers/symbol_analyzer.rs
@@ -250,17 +250,15 @@ impl SymbolAnalyzer {
                         .is_some_and(|symbols| symbols.contains(*symbol));
 
                     if enable_logging {
-                        if !is_kept {
-                            debug!(
-                                "Filtering out symbol '{symbol}' from __all__ of module \
-                                 '{module_name}' - removed by tree-shaking"
-                            );
+                        let (action, preposition, reason) = if is_kept {
+                            ("Keeping", "in", "survived")
                         } else {
-                            debug!(
-                                "Keeping symbol '{symbol}' in __all__ of module '{module_name}' - \
-                                 survived tree-shaking"
-                            );
-                        }
+                            ("Filtering out", "from", "removed by")
+                        };
+                        debug!(
+                            "{action} symbol '{symbol}' {preposition} __all__ of module \
+                             '{module_name}' - {reason} tree-shaking"
+                        );
                     }
 
                     is_kept

--- a/crates/cribo/src/analyzers/symbol_analyzer.rs
+++ b/crates/cribo/src/analyzers/symbol_analyzer.rs
@@ -228,7 +228,7 @@ impl SymbolAnalyzer {
     /// # Arguments
     /// * `exports` - The list of export symbols to filter
     /// * `module_name` - The name of the module these exports belong to
-    /// * `kept_symbols` - Optional set of (module, symbol) pairs that survived tree-shaking
+    /// * `kept_symbols` - Optional map from module name to a set of symbols to keep in that module
     /// * `enable_logging` - Whether to log debug information about kept/filtered symbols
     ///
     /// # Returns

--- a/crates/cribo/src/code_generator/further-split-misses.md
+++ b/crates/cribo/src/code_generator/further-split-misses.md
@@ -26,7 +26,7 @@ The following functions were identified as candidates for extraction in `further
 - ✅ `create_namespace_statements` (~15 lines)
 - ✅ `create_namespace_attribute` (~15 lines)
 - `sort_wrapped_modules_by_dependencies` (~10 lines)
-- `filter_exports_by_tree_shaking` (~10 lines)
+- ✅ `filter_exports_by_tree_shaking` (~10 lines)
 - `should_inline_symbol` (~10 lines)
 
 ## 2. Functions Using Wrappers Instead of Direct Calls

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -1806,8 +1806,9 @@ impl<'a> RecursiveImportTransformer<'a> {
                 }
 
                 // Check if this symbol survived tree-shaking
-                if let Some(ref kept_symbols) = self.bundler.tree_shaking_keep_symbols
-                    && !kept_symbols.contains(&(module_name.to_string(), original_name.clone()))
+                if !self
+                    .bundler
+                    .is_symbol_kept_by_tree_shaking(module_name, original_name)
                 {
                     log::debug!(
                         "Skipping tree-shaken symbol '{original_name}' from namespace for module \
@@ -1837,8 +1838,9 @@ impl<'a> RecursiveImportTransformer<'a> {
                     module_renames.is_some_and(|renames| renames.contains_key(export));
                 if !was_renamed && !seen_args.contains(export) {
                     // Check if this symbol survived tree-shaking
-                    if let Some(ref kept_symbols) = self.bundler.tree_shaking_keep_symbols
-                        && !kept_symbols.contains(&(module_name.to_string(), export.clone()))
+                    if !self
+                        .bundler
+                        .is_symbol_kept_by_tree_shaking(module_name, export)
                     {
                         log::debug!(
                             "Skipping tree-shaken export '{export}' from namespace for module \
@@ -2458,9 +2460,7 @@ pub(super) fn handle_imports_from_inlined_module_with_context(
         };
 
         // Check if the source symbol was tree-shaken
-        if let Some(kept_symbols) = bundler.tree_shaking_keep_symbols.as_ref()
-            && !kept_symbols.contains(&(module_name.to_string(), imported_name.to_string()))
-        {
+        if !bundler.is_symbol_kept_by_tree_shaking(module_name, imported_name) {
             log::debug!(
                 "Skipping import assignment for tree-shaken symbol '{imported_name}' from module \
                  '{module_name}'"

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -11,6 +11,7 @@ use ruff_python_ast::{
 use ruff_text_size::TextRange;
 
 use crate::{
+    analyzers::symbol_analyzer::SymbolAnalyzer,
     ast_builder::{expressions, statements},
     code_generator::{
         bundler::Bundler, import_deduplicator, module_registry::sanitize_module_name_for_identifier,
@@ -858,11 +859,16 @@ impl<'a> RecursiveImportTransformer<'a> {
                                 {
                                     // Filter exports to only include symbols that survived
                                     // tree-shaking
-                                    let filtered_exports =
-                                        self.bundler.filter_exports_by_tree_shaking(
-                                            &full_module_path,
+                                    let filtered_exports: Vec<String> =
+                                        SymbolAnalyzer::filter_exports_by_tree_shaking(
                                             &exports,
-                                        );
+                                            &full_module_path,
+                                            self.bundler.tree_shaking_keep_symbols.as_ref(),
+                                            false,
+                                        )
+                                        .into_iter()
+                                        .cloned()
+                                        .collect();
 
                                     // Add __all__ attribute to the namespace with filtered exports
                                     // BUT ONLY if the original module had an explicit __all__
@@ -929,11 +935,16 @@ impl<'a> RecursiveImportTransformer<'a> {
                                 {
                                     // Filter exports to only include symbols that survived
                                     // tree-shaking
-                                    let filtered_exports =
-                                        self.bundler.filter_exports_by_tree_shaking(
-                                            &full_module_path,
+                                    let filtered_exports: Vec<String> =
+                                        SymbolAnalyzer::filter_exports_by_tree_shaking(
                                             &exports,
-                                        );
+                                            &full_module_path,
+                                            self.bundler.tree_shaking_keep_symbols.as_ref(),
+                                            false,
+                                        )
+                                        .into_iter()
+                                        .cloned()
+                                        .collect();
 
                                     // Add __all__ attribute to the namespace with filtered exports
                                     // BUT ONLY if the original module had an explicit __all__

--- a/crates/cribo/src/code_generator/namespace_manager.rs
+++ b/crates/cribo/src/code_generator/namespace_manager.rs
@@ -586,9 +586,7 @@ pub(super) fn create_namespace_for_inlined_module_static(
         }
 
         // Check if this symbol survived tree-shaking
-        if let Some(ref kept_symbols) = bundler.tree_shaking_keep_symbols
-            && !kept_symbols.contains(&(module_name.to_string(), original_name.clone()))
-        {
+        if !bundler.is_symbol_kept_by_tree_shaking(module_name, original_name) {
             log::debug!(
                 "Skipping tree-shaken symbol '{original_name}' from namespace for module \
                  '{module_name}'"
@@ -614,9 +612,7 @@ pub(super) fn create_namespace_for_inlined_module_static(
             // Check if this export was already added as a renamed symbol
             if !module_renames.contains_key(export) && !seen_args.contains(export) {
                 // Check if this symbol survived tree-shaking
-                if let Some(ref kept_symbols) = bundler.tree_shaking_keep_symbols
-                    && !kept_symbols.contains(&(module_name.to_string(), export.clone()))
-                {
+                if !bundler.is_symbol_kept_by_tree_shaking(module_name, export) {
                     log::debug!(
                         "Skipping tree-shaken export '{export}' from namespace for module \
                          '{module_name}'"

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -777,7 +777,10 @@ impl TreeShaker {
     }
 
     /// Get symbols that survive tree-shaking for a module
-    pub fn get_used_symbols_for_module(&self, module_name: &str) -> IndexSet<String> {
+    pub fn get_used_symbols_for_module(
+        &self,
+        module_name: &str,
+    ) -> crate::types::FxIndexSet<String> {
         self.used_symbols
             .iter()
             .filter(|(module, _)| module == module_name)


### PR DESCRIPTION
## Summary

This PR consolidates two duplicate `filter_exports_by_tree_shaking` functions from `bundler.rs` into a single static method in `SymbolAnalyzer`, reducing code duplication and improving code organization.

## Changes

- **Added** new public static method `SymbolAnalyzer::filter_exports_by_tree_shaking` that combines logic from both original functions
- **Updated** both call sites in `import_transformer.rs` to use the new method with `enable_logging=false`
- **Updated** call site in `bundler.rs` to use the new method with `enable_logging=true`
- **Removed** both old functions from `bundler.rs` (~55 lines removed)
- **Added** `IndexSet` import to `symbol_analyzer.rs`

## Technical Details

The new method in `analyzers/symbol_analyzer.rs`:
- Takes borrowed slices and returns borrowed references for efficiency
- Has an `enable_logging` parameter to control debug output
- Call sites handle cloning when needed with `.into_iter().cloned().collect()`

## Test Results

✅ All tests pass (`cargo test --workspace`)
✅ No clippy errors (`cargo clippy --workspace --all-targets`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized tree-shaking symbol filtering and membership checks, improving consistency and simplifying export handling.
  * Replaced direct symbol presence checks with a unified method across modules for better maintainability.
  * Updated internal symbol tracking to use a nested map structure for more efficient tree-shaking management.

* **Chores**
  * Updated documentation to reflect extraction and relocation of export filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->