### PR TITLE
refactor: move process_wrapper_module_globals to globals module

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -978,39 +978,6 @@ impl<'a> Bundler<'a> {
         Ok(sorted_modules)
     }
 
-    /// Process wrapper module globals (matching original implementation)
-    fn process_wrapper_module_globals(
-        &self,
-        params: &ProcessGlobalsParams,
-        module_globals: &mut FxIndexMap<String, crate::semantic_bundler::ModuleGlobalInfo>,
-        all_lifted_declarations: &mut Vec<Stmt>,
-    ) {
-        // Get module ID from graph
-        let module = match params
-            .semantic_ctx
-            .graph
-            .get_module_by_name(params.module_name)
-        {
-            Some(m) => m,
-            None => return,
-        };
-
-        let module_id = module.module_id;
-        let global_info = params.semantic_ctx.semantic_bundler.analyze_module_globals(
-            module_id,
-            params.ast,
-            params.module_name,
-        );
-
-        // Create GlobalsLifter and collect declarations
-        if !global_info.global_declarations.is_empty() {
-            let globals_lifter = crate::code_generator::globals::GlobalsLifter::new(&global_info);
-            all_lifted_declarations.extend(globals_lifter.get_lifted_declarations());
-        }
-
-        module_globals.insert(params.module_name.to_string(), global_info);
-    }
-
     /// Transform module to cache init function
     fn transform_module_to_cache_init_function(
         &mut self,
@@ -2484,7 +2451,7 @@ impl<'a> Bundler<'a> {
                         ast,
                         semantic_ctx: &semantic_ctx,
                     };
-                    self.process_wrapper_module_globals(
+                    crate::code_generator::globals::process_wrapper_module_globals(
                         &params,
                         &mut module_globals,
                         &mut lifted_declarations,
@@ -3311,7 +3278,7 @@ impl<'a> Bundler<'a> {
                     ast,
                     semantic_ctx: &semantic_ctx,
                 };
-                self.process_wrapper_module_globals(
+                crate::code_generator::globals::process_wrapper_module_globals(
                     &params,
                     &mut module_globals,
                     &mut all_lifted_declarations,

--- a/crates/cribo/src/code_generator/further-split-misses.md
+++ b/crates/cribo/src/code_generator/further-split-misses.md
@@ -19,7 +19,7 @@ The following functions were identified as candidates for extraction in `further
 - ✅ `collect_imports_from_module` (~40 lines)
 - ✅ `sort_wrapper_modules_by_dependencies` (~25 lines)
 - `transform_module_to_cache_init_function` (~20 lines)
-- `process_wrapper_module_globals` (~20 lines)
+- ✅ `process_wrapper_module_globals` (~20 lines)
 - ✅ `is_package_init_reexport` (~20 lines)
 - ✅ `create_namespace_with_name` (~15 lines)
 - `collect_future_imports_from_ast` (~15 lines)

--- a/crates/cribo/src/code_generator/globals.rs
+++ b/crates/cribo/src/code_generator/globals.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{Expr, ExprContext, Stmt};
 
 use crate::{
     ast_builder::{expressions, statements},
+    code_generator::context::ProcessGlobalsParams,
     semantic_bundler::ModuleGlobalInfo,
     types::FxIndexMap,
 };
@@ -180,4 +181,36 @@ impl GlobalsLifter {
     pub fn get_lifted_names(&self) -> &FxIndexMap<String, String> {
         &self.lifted_names
     }
+}
+
+/// Process wrapper module globals (matching original implementation)
+pub fn process_wrapper_module_globals(
+    params: &ProcessGlobalsParams,
+    module_globals: &mut FxIndexMap<String, ModuleGlobalInfo>,
+    all_lifted_declarations: &mut Vec<Stmt>,
+) {
+    // Get module ID from graph
+    let module = match params
+        .semantic_ctx
+        .graph
+        .get_module_by_name(params.module_name)
+    {
+        Some(m) => m,
+        None => return,
+    };
+
+    let module_id = module.module_id;
+    let global_info = params.semantic_ctx.semantic_bundler.analyze_module_globals(
+        module_id,
+        params.ast,
+        params.module_name,
+    );
+
+    // Create GlobalsLifter and collect declarations
+    if !global_info.global_declarations.is_empty() {
+        let globals_lifter = GlobalsLifter::new(&global_info);
+        all_lifted_declarations.extend(globals_lifter.get_lifted_declarations());
+    }
+
+    module_globals.insert(params.module_name.to_string(), global_info);
 }


### PR DESCRIPTION
## Summary
- Moved `process_wrapper_module_globals` function from `bundler.rs` to `globals.rs`
- Updated both callsites to use the function from the globals module
- Improved code organization by consolidating global-related functionality

## Changes
- Extracted the function from `Bundler` impl block to make it a standalone public function
- Added necessary import for `ProcessGlobalsParams` to `globals.rs`
- Updated two callsites in `bundler.rs` to use `crate::code_generator::globals::process_wrapper_module_globals`

## Test plan
- [x] All existing tests pass (`cargo test --workspace`)
- [x] No new clippy warnings introduced (`cargo clippy --workspace --all-targets`)
- [x] Function behavior remains identical after refactoring

🤖 Generated with [Claude Code](https://claude.ai/code)