### PR TITLE
refactor: consolidate relative import resolution into ModuleResolver

### DIFF
--- a/crates/cribo/benches/bundling.rs
+++ b/crates/cribo/benches/bundling.rs
@@ -116,7 +116,7 @@ fn benchmark_module_resolution(c: &mut Criterion) {
         let mut config = Config::default();
         config.src.push(temp_dir.path().to_path_buf());
 
-        let mut resolver = ModuleResolver::new(config).expect("Failed to create resolver");
+        let resolver = ModuleResolver::new(config).expect("Failed to create resolver");
 
         b.iter(|| {
             // Benchmark module resolution

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -146,23 +146,44 @@ impl<'a> RecursiveImportTransformer<'a> {
                 if let Expr::StringLiteral(package_lit) = &call.arguments.args[1] {
                     let package = package_lit.value.to_str();
 
-                    // Resolve relative import
-                    let level = module_name.chars().take_while(|&c| c == '.').count();
-                    let name_part = module_name.trim_start_matches('.');
+                    // Resolve package to path, then use resolver
+                    if let Ok(Some(package_path)) =
+                        self.bundler.resolver.resolve_module_path(package)
+                    {
+                        let level = module_name.chars().take_while(|&c| c == '.').count() as u32;
+                        let name_part = module_name.trim_start_matches('.');
 
-                    let mut package_parts: Vec<&str> = package.split('.').collect();
+                        self.bundler
+                            .resolver
+                            .resolve_relative_to_absolute_module_name(
+                                level,
+                                if name_part.is_empty() {
+                                    None
+                                } else {
+                                    Some(name_part)
+                                },
+                                &package_path,
+                            )
+                            .unwrap_or_else(|| module_name.to_string())
+                    } else {
+                        // Fallback to manual resolution if package path not found
+                        let level = module_name.chars().take_while(|&c| c == '.').count();
+                        let name_part = module_name.trim_start_matches('.');
 
-                    // Go up 'level - 1' levels (one dot means current package)
-                    if level > 1 && package_parts.len() >= level - 1 {
-                        package_parts.truncate(package_parts.len() - (level - 1));
+                        let mut package_parts: Vec<&str> = package.split('.').collect();
+
+                        // Go up 'level - 1' levels (one dot means current package)
+                        if level > 1 && package_parts.len() >= level - 1 {
+                            package_parts.truncate(package_parts.len() - (level - 1));
+                        }
+
+                        // Append the name part if it's not empty
+                        if !name_part.is_empty() {
+                            package_parts.push(name_part);
+                        }
+
+                        package_parts.join(".")
                     }
-
-                    // Append the name part if it's not empty
-                    if !name_part.is_empty() {
-                        package_parts.push(name_part);
-                    }
-
-                    package_parts.join(".")
                 } else {
                     module_name.to_string()
                 }
@@ -525,13 +546,19 @@ impl<'a> RecursiveImportTransformer<'a> {
                     }
 
                     // Resolve relative imports first
-                    let resolved_module = resolve_relative_import_with_context(
-                        import_from,
-                        self.module_name,
-                        self.module_path,
-                        self.bundler.entry_path.as_deref(),
-                        &self.bundler.bundled_modules,
-                    );
+                    let resolved_module = if import_from.level > 0 {
+                        self.module_path.and_then(|path| {
+                            self.bundler
+                                .resolver
+                                .resolve_relative_to_absolute_module_name(
+                                    import_from.level,
+                                    import_from.module.as_ref().map(|id| id.as_str()),
+                                    path,
+                                )
+                        })
+                    } else {
+                        import_from.module.as_ref().map(|m| m.to_string())
+                    };
 
                     if let Some(resolved) = &resolved_module {
                         // Track aliases for imported symbols (non-importlib)
@@ -612,13 +639,19 @@ impl<'a> RecursiveImportTransformer<'a> {
         );
 
         // Resolve relative imports
-        let resolved_module = resolve_relative_import_with_context(
-            import_from,
-            self.module_name,
-            self.module_path,
-            self.bundler.entry_path.as_deref(),
-            &self.bundler.bundled_modules,
-        );
+        let resolved_module = if import_from.level > 0 {
+            self.module_path.and_then(|path| {
+                self.bundler
+                    .resolver
+                    .resolve_relative_to_absolute_module_name(
+                        import_from.level,
+                        import_from.module.as_ref().map(|id| id.as_str()),
+                        path,
+                    )
+            })
+        } else {
+            import_from.module.as_ref().map(|m| m.to_string())
+        };
 
         log::debug!(
             "handle_import_from: resolved_module={:?}, is_wrapper_init={}, current_module={}",
@@ -1193,6 +1226,7 @@ impl<'a> RecursiveImportTransformer<'a> {
             self.bundler,
             import_from.clone(),
             self.module_name,
+            self.module_path,
             &empty_renames,
             self.is_wrapper_init,
         )
@@ -2049,6 +2083,7 @@ fn rewrite_import_from(
     bundler: &Bundler,
     import_from: StmtImportFrom,
     current_module: &str,
+    module_path: Option<&Path>,
     symbol_renames: &FxIndexMap<String, FxIndexMap<String, String>>,
     inside_wrapper_init: bool,
 ) -> Vec<Stmt> {
@@ -2068,13 +2103,17 @@ fn rewrite_import_from(
     );
     log::trace!("  bundled_modules size: {}", bundler.bundled_modules.len());
     log::trace!("  inlined_modules size: {}", bundler.inlined_modules.len());
-    let resolved_module_name = resolve_relative_import_with_context(
-        &import_from,
-        current_module,
-        None,
-        bundler.entry_path.as_deref(),
-        &bundler.bundled_modules,
-    );
+    let resolved_module_name = if import_from.level > 0 {
+        module_path.and_then(|path| {
+            bundler.resolver.resolve_relative_to_absolute_module_name(
+                import_from.level,
+                import_from.module.as_ref().map(|id| id.as_str()),
+                path,
+            )
+        })
+    } else {
+        import_from.module.as_ref().map(|m| m.to_string())
+    };
 
     let Some(module_name) = resolved_module_name else {
         // If we can't resolve the module, return the original import
@@ -2221,198 +2260,6 @@ fn rewrite_import_from(
 ///
 /// This function resolves relative imports (e.g., `from . import foo` or `from ..bar import baz`)
 /// to absolute module names based on the current module and its file path.
-///
-/// # Arguments
-/// * `import_from` - The import statement to resolve
-/// * `current_module` - The name of the module containing the import
-/// * `module_path` - Optional path to the module file (used to detect __init__.py)
-/// * `entry_path` - Optional entry point path for the bundle
-/// * `bundled_modules` - Set of all bundled module names
-///
-/// # Returns
-/// The resolved absolute module name, or None if the import cannot be resolved
-pub fn resolve_relative_import_with_context(
-    import_from: &StmtImportFrom,
-    current_module: &str,
-    module_path: Option<&Path>,
-    entry_path: Option<&str>,
-    bundled_modules: &FxIndexSet<String>,
-) -> Option<String> {
-    log::debug!(
-        "Resolving relative import: level={}, module={:?}, current_module={}",
-        import_from.level,
-        import_from.module,
-        current_module
-    );
-
-    if import_from.level > 0 {
-        // This is a relative import
-        let mut parts: Vec<&str> = current_module.split('.').collect();
-
-        // Special handling for different module types
-        if parts.len() == 1 && import_from.level == 1 {
-            // For single-component modules with level 1 imports, we need to determine
-            // if this is a root-level module or a package __init__ file
-
-            // Check if current module is a package __init__.py file
-            let is_package_init = if let Some(path) = module_path {
-                path.file_name()
-                    .and_then(|f| f.to_str())
-                    .map(|f| f == "__init__.py")
-                    .unwrap_or(false)
-            } else {
-                false
-            };
-
-            // Check if this module is the entry module and is __init__.py
-            let is_entry_init = current_module
-                == entry_path
-                    .map(Path::new)
-                    .and_then(Path::file_stem)
-                    .and_then(std::ffi::OsStr::to_str)
-                    .unwrap_or("")
-                && is_package_init;
-
-            if is_entry_init {
-                // This is the entry __init__.py - relative imports should resolve within the
-                // package but without the package prefix
-                log::debug!(
-                    "Module '{current_module}' is the entry __init__.py, clearing parts for \
-                     relative import"
-                );
-                parts.clear();
-            } else {
-                // Check if this module is in the bundled_modules to
-                // determine if it's a package
-                let is_package = bundled_modules
-                    .iter()
-                    .any(|m| m.starts_with(&format!("{current_module}.")));
-
-                if is_package {
-                    // This is a package __init__ file - level 1 imports stay in the package
-                    log::debug!(
-                        "Module '{current_module}' is a package, keeping parts for relative import"
-                    );
-                    // Keep parts as is
-                } else {
-                    // This is a root-level module - level 1 imports are siblings
-                    log::debug!(
-                        "Module '{current_module}' is root-level, clearing parts for relative \
-                         import"
-                    );
-                    parts.clear();
-                }
-            }
-        } else {
-            // For modules with multiple components (e.g., "greetings.greeting")
-            // Special handling: if this module represents a package __init__.py file,
-            // the first level doesn't remove anything (stays in the package)
-            // Subsequent levels go up the hierarchy
-
-            // Check if current module is a package __init__.py file
-            let is_package_init = if let Some(path) = module_path {
-                path.file_name()
-                    .and_then(|f| f.to_str())
-                    .map(|f| f == "__init__.py")
-                    .unwrap_or(false)
-            } else {
-                // Fallback: check if module has submodules
-                bundled_modules
-                    .iter()
-                    .any(|m| m.starts_with(&format!("{current_module}.")))
-            };
-
-            let levels_to_remove = if is_package_init {
-                // For package __init__.py files, the first dot stays in the package
-                // So we remove (level - 1) parts
-                import_from.level.saturating_sub(1)
-            } else {
-                // For regular modules, remove 'level' parts
-                import_from.level
-            };
-
-            log::debug!(
-                "Relative import resolution: current_module={}, is_package_init={}, level={}, \
-                 levels_to_remove={}, parts={:?}",
-                current_module,
-                is_package_init,
-                import_from.level,
-                levels_to_remove,
-                parts
-            );
-
-            for _ in 0..levels_to_remove {
-                if parts.is_empty() {
-                    log::debug!("Invalid relative import - ran out of parent levels");
-                    return None; // Invalid relative import
-                }
-                parts.pop();
-            }
-        }
-
-        // Add the module name if specified
-        if let Some(ref module) = import_from.module {
-            parts.push(module.as_str());
-        }
-
-        let resolved = parts.join(".");
-
-        // Handle the case where relative import resolves to empty or just the package itself
-        // This happens with "from . import something" in a package __init__.py
-        if resolved.is_empty() {
-            // For "from . import X" in a package, the resolved module is the current package
-            // We need to check if we're in a package __init__.py
-            if import_from.level == 1 && import_from.module.is_none() {
-                // This is "from . import X" - we need to determine the parent package
-                // For a module like "requests.utils", the parent is "requests"
-                // For a module like "__init__", it's the current directory
-                if current_module.contains('.') {
-                    // Module has a parent package - extract it
-                    let parent_parts: Vec<&str> = current_module.split('.').collect();
-                    let parent = parent_parts[..parent_parts.len() - 1].join(".");
-                    log::debug!(
-                        "Relative import 'from . import' in module '{current_module}' - returning \
-                         parent package '{parent}'"
-                    );
-                    return Some(parent);
-                } else if current_module == "__init__" {
-                    // This is a package __init__.py doing "from . import X"
-                    // The package name should be derived from the directory
-                    log::debug!(
-                        "Relative import 'from . import' in __init__ module - this case needs \
-                         special handling"
-                    );
-                    // For now, we'll return None and let it be handled elsewhere
-                    return None;
-                } else {
-                    // Single-level module doing "from . import X" - this is importing from the
-                    // same directory We need to return empty string to
-                    // indicate current directory
-                    log::debug!(
-                        "Relative import 'from . import' in root-level module '{current_module}' \
-                         - returning empty for current directory"
-                    );
-                    return Some(String::new());
-                }
-            }
-            log::debug!("Invalid relative import - resolved to empty module");
-            return None;
-        }
-
-        // Check for potential circular import
-        if resolved == current_module {
-            log::warn!("Potential circular import detected: {current_module} importing itself");
-        }
-
-        log::debug!("Resolved relative import to: {resolved}");
-        Some(resolved)
-    } else {
-        // Not a relative import
-        let resolved = import_from.module.as_ref().map(|m| m.as_str().to_string());
-        log::debug!("Not a relative import, resolved to: {resolved:?}");
-        resolved
-    }
-}
 
 /// Handle imports from inlined modules
 pub(super) fn handle_imports_from_inlined_module_with_context(

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -166,23 +166,21 @@ impl<'a> RecursiveImportTransformer<'a> {
                             )
                             .unwrap_or_else(|| module_name.to_string())
                     } else {
-                        // Fallback to manual resolution if package path not found
-                        let level = module_name.chars().take_while(|&c| c == '.').count();
+                        // Use resolver's method for package name resolution when path not found
+                        let level = module_name.chars().take_while(|&c| c == '.').count() as u32;
                         let name_part = module_name.trim_start_matches('.');
 
-                        let mut package_parts: Vec<&str> = package.split('.').collect();
-
-                        // Go up 'level - 1' levels (one dot means current package)
-                        if level > 1 && package_parts.len() >= level - 1 {
-                            package_parts.truncate(package_parts.len() - (level - 1));
-                        }
-
-                        // Append the name part if it's not empty
-                        if !name_part.is_empty() {
-                            package_parts.push(name_part);
-                        }
-
-                        package_parts.join(".")
+                        self.bundler
+                            .resolver
+                            .resolve_relative_import_from_package_name(
+                                level,
+                                if name_part.is_empty() {
+                                    None
+                                } else {
+                                    Some(name_part)
+                                },
+                                package,
+                            )
                     }
                 } else {
                     module_name.to_string()

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -449,7 +449,7 @@ impl BundleOrchestrator {
         let mut build_params = GraphBuildParams {
             entry_path,
             entry_module_name: &entry_module_name,
-            resolver: &mut resolver,
+            resolver: &resolver,
             graph,
         };
         let parsed_modules = self.build_dependency_graph(&mut build_params)?;
@@ -657,7 +657,7 @@ impl BundleOrchestrator {
             self.bundle_core(entry_path, &mut graph, &mut resolver_opt)?;
 
         // Extract the resolver (it's guaranteed to be Some after bundle_core)
-        let mut resolver = resolver_opt.expect("Resolver should be initialized by bundle_core");
+        let resolver = resolver_opt.expect("Resolver should be initialized by bundle_core");
 
         let sorted_modules =
             self.get_sorted_modules_from_graph(&graph, circular_dep_analysis.as_ref())?;
@@ -673,7 +673,7 @@ impl BundleOrchestrator {
         let bundled_code = self.emit_static_bundle(StaticBundleParams {
             sorted_modules: &module_data,
             parsed_modules: Some(&parsed_modules),
-            resolver: &mut resolver,
+            resolver: &resolver,
             entry_module_name: &entry_module_name,
             graph: &graph,
             circular_dep_analysis: circular_dep_analysis.as_ref(),
@@ -682,7 +682,7 @@ impl BundleOrchestrator {
 
         // Generate requirements.txt if requested
         if emit_requirements {
-            self.write_requirements_file_for_stdout(&module_data, &mut resolver)?;
+            self.write_requirements_file_for_stdout(&module_data, &resolver)?;
         }
 
         Ok(bundled_code)
@@ -707,7 +707,7 @@ impl BundleOrchestrator {
             self.bundle_core(entry_path, &mut graph, &mut resolver_opt)?;
 
         // Extract the resolver (it's guaranteed to be Some after bundle_core)
-        let mut resolver = resolver_opt.expect("Resolver should be initialized by bundle_core");
+        let resolver = resolver_opt.expect("Resolver should be initialized by bundle_core");
 
         let sorted_modules =
             self.get_sorted_modules_from_graph(&graph, circular_dep_analysis.as_ref())?;
@@ -717,7 +717,7 @@ impl BundleOrchestrator {
         let bundled_code = self.emit_static_bundle(StaticBundleParams {
             sorted_modules: &sorted_modules,
             parsed_modules: Some(&parsed_modules), // Use pre-parsed modules to avoid double parsing
-            resolver: &mut resolver,
+            resolver: &resolver,
             entry_module_name: &entry_module_name,
             graph: &graph,
             circular_dep_analysis: circular_dep_analysis.as_ref(),
@@ -726,7 +726,7 @@ impl BundleOrchestrator {
 
         // Generate requirements.txt if requested
         if emit_requirements {
-            self.write_requirements_file(&sorted_modules, &mut resolver, output_path)?;
+            self.write_requirements_file(&sorted_modules, &resolver, output_path)?;
         }
 
         // Write output file
@@ -1459,7 +1459,7 @@ impl BundleOrchestrator {
     fn write_requirements_file_for_stdout(
         &self,
         sorted_modules: &[(String, PathBuf, Vec<String>)],
-        resolver: &mut ModuleResolver,
+        resolver: &ModuleResolver,
     ) -> Result<()> {
         let requirements_content = self.generate_requirements(sorted_modules, resolver)?;
         if !requirements_content.is_empty() {
@@ -1480,7 +1480,7 @@ impl BundleOrchestrator {
     fn write_requirements_file(
         &self,
         sorted_modules: &[(String, PathBuf, Vec<String>)],
-        resolver: &mut ModuleResolver,
+        resolver: &ModuleResolver,
         output_path: &Path,
     ) -> Result<()> {
         let requirements_content = self.generate_requirements(sorted_modules, resolver)?;
@@ -1623,7 +1623,7 @@ impl BundleOrchestrator {
     fn generate_requirements(
         &self,
         modules: &[(String, PathBuf, Vec<String>)],
-        resolver: &mut ModuleResolver,
+        resolver: &ModuleResolver,
     ) -> Result<String> {
         let mut third_party_imports = IndexSet::new();
 

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -118,7 +118,7 @@ type ImportExtractionResult = Vec<(
 
 /// Parameters for discovery phase operations
 struct DiscoveryParams<'a> {
-    resolver: &'a mut ModuleResolver,
+    resolver: &'a ModuleResolver,
     modules_to_process: &'a mut ModuleQueue,
     processed_modules: &'a ProcessedModules,
     queued_modules: &'a mut IndexSet<String>,
@@ -128,7 +128,7 @@ struct DiscoveryParams<'a> {
 struct StaticBundleParams<'a> {
     sorted_modules: &'a [(String, PathBuf, Vec<String>)],
     parsed_modules: Option<&'a [ParsedModuleData]>, // Optional pre-parsed modules
-    _resolver: &'a ModuleResolver,                  // Unused but kept for future use
+    resolver: &'a ModuleResolver,
     entry_module_name: &'a str,
     graph: &'a CriboGraph,
     circular_dep_analysis: Option<&'a CircularDependencyAnalysis>,
@@ -137,7 +137,7 @@ struct StaticBundleParams<'a> {
 
 /// Context for dependency building operations
 struct DependencyContext<'a> {
-    resolver: &'a mut ModuleResolver,
+    resolver: &'a ModuleResolver,
     graph: &'a mut CriboGraph,
     module_id_map: &'a indexmap::IndexMap<String, crate::cribo_graph::ModuleId>,
     current_module: &'a str,
@@ -148,7 +148,7 @@ struct DependencyContext<'a> {
 struct GraphBuildParams<'a> {
     entry_path: &'a Path,
     entry_module_name: &'a str,
-    resolver: &'a mut ModuleResolver,
+    resolver: &'a ModuleResolver,
     graph: &'a mut CriboGraph,
 }
 
@@ -673,7 +673,7 @@ impl BundleOrchestrator {
         let bundled_code = self.emit_static_bundle(StaticBundleParams {
             sorted_modules: &module_data,
             parsed_modules: Some(&parsed_modules),
-            _resolver: &resolver,
+            resolver: &mut resolver,
             entry_module_name: &entry_module_name,
             graph: &graph,
             circular_dep_analysis: circular_dep_analysis.as_ref(),
@@ -717,7 +717,7 @@ impl BundleOrchestrator {
         let bundled_code = self.emit_static_bundle(StaticBundleParams {
             sorted_modules: &sorted_modules,
             parsed_modules: Some(&parsed_modules), // Use pre-parsed modules to avoid double parsing
-            _resolver: &resolver,
+            resolver: &mut resolver,
             entry_module_name: &entry_module_name,
             graph: &graph,
             circular_dep_analysis: circular_dep_analysis.as_ref(),
@@ -1022,7 +1022,7 @@ impl BundleOrchestrator {
         &self,
         ast: &ModModule,
         file_path: &Path,
-        mut resolver: Option<&mut ModuleResolver>,
+        mut resolver: Option<&ModuleResolver>,
     ) -> Result<ImportExtractionResult> {
         let mut visitor = ImportDiscoveryVisitor::new();
         for stmt in &ast.body {
@@ -1142,10 +1142,23 @@ impl BundleOrchestrator {
         &self,
         import: &crate::visitors::DiscoveredImport,
         file_path: &Path,
-        resolver: &mut Option<&mut ModuleResolver>,
+        resolver: &mut Option<&ModuleResolver>,
         imports: &mut IndexSet<String>,
     ) {
-        let base_module = match self.resolve_relative_import(file_path, import.level) {
+        // Get resolver reference
+        let resolver_ref = match resolver {
+            Some(resolver) => resolver,
+            None => {
+                debug!("No resolver available for relative import resolution");
+                return;
+            }
+        };
+
+        let base_module = match resolver_ref.resolve_relative_to_absolute_module_name(
+            import.level,
+            None, // Don't include module_name here, we'll handle it separately
+            file_path,
+        ) {
             Some(module) => module,
             None => {
                 debug!(
@@ -1195,7 +1208,7 @@ impl BundleOrchestrator {
     fn process_single_name_import_set(
         &self,
         import: &crate::visitors::DiscoveredImport,
-        resolver: &mut Option<&mut ModuleResolver>,
+        resolver: &mut Option<&ModuleResolver>,
         imports: &mut IndexSet<String>,
     ) {
         if let Some(resolver) = resolver {
@@ -1213,7 +1226,7 @@ impl BundleOrchestrator {
         &self,
         module_name: &str,
         import: &crate::visitors::DiscoveredImport,
-        resolver: &mut Option<&mut ModuleResolver>,
+        resolver: &mut Option<&ModuleResolver>,
         imports: &mut IndexSet<String>,
     ) {
         let Some(resolver) = resolver else { return };
@@ -1228,83 +1241,6 @@ impl BundleOrchestrator {
                 imports.insert(full_module_name);
                 debug!("Detected submodule import: {name} from {module_name}");
             }
-        }
-    }
-
-    /// Resolve a relative import to its absolute module name
-    /// Returns None if the relative import goes beyond the module hierarchy
-    #[allow(clippy::manual_ok_err)]
-    fn resolve_relative_import(&self, file_path: &Path, level: u32) -> Option<String> {
-        // Get the directory containing the current file
-        let current_dir = file_path.parent()?;
-
-        // Convert current_dir to absolute path if it's relative
-        let absolute_current_dir = if current_dir.is_absolute() {
-            current_dir.to_path_buf()
-        } else {
-            let current_working_dir = match std::env::current_dir() {
-                Ok(dir) => dir,
-                Err(_) => return None,
-            };
-            current_working_dir.join(current_dir)
-        };
-
-        // Find which source directory contains this file
-        let relative_dir = self.config.src.iter().find_map(|src_dir| {
-            // Handle case where paths might be relative vs absolute
-            if src_dir.is_absolute() {
-                match absolute_current_dir.strip_prefix(src_dir) {
-                    Ok(path) => Some(path),
-                    Err(_) => None,
-                }
-            } else {
-                // For relative source directories, we need to resolve them relative to the current
-                // working directory
-                let current_working_dir = match std::env::current_dir() {
-                    Ok(dir) => dir,
-                    Err(_) => return None,
-                };
-                let absolute_src_dir = current_working_dir.join(src_dir);
-                match absolute_current_dir.strip_prefix(&absolute_src_dir) {
-                    Ok(path) => Some(path),
-                    Err(_) => None,
-                }
-            }
-        })?;
-
-        // Convert directory path to module path components
-        let module_parts: Vec<String> = if relative_dir == Path::new("") {
-            // If relative_dir is empty, we're at the root of the source directory
-            Vec::new()
-        } else {
-            relative_dir
-                .components()
-                .map(|c| c.as_os_str().to_string_lossy().into_owned())
-                .collect()
-        };
-
-        // Apply relative import logic
-        let mut current_parts = module_parts;
-
-        // Remove 'level' number of components from the end
-        // For level=1 (.), we stay in current package
-        // For level=2 (..), we go to parent package, etc.
-        if level as usize > current_parts.len() + 1 {
-            // Cannot go beyond the root of the project
-            return None;
-        }
-
-        // Remove (level - 1) components since level=1 means current package
-        for _ in 0..(level.saturating_sub(1)) {
-            current_parts.pop();
-        }
-
-        if current_parts.is_empty() {
-            // If we're at the root after applying relative levels, return empty string
-            // This will be handled by the caller to construct the full import name
-            Some(String::new())
-        } else {
-            Some(current_parts.join("."))
         }
     }
 
@@ -1582,7 +1518,7 @@ impl BundleOrchestrator {
             }
         }
 
-        let mut static_bundler = Bundler::new(Some(&self.module_registry));
+        let mut static_bundler = Bundler::new(Some(&self.module_registry), params.resolver);
 
         // Parse all modules and prepare them for bundling
         let mut module_asts = Vec::new();

--- a/crates/cribo/src/resolver.rs
+++ b/crates/cribo/src/resolver.rs
@@ -733,10 +733,11 @@ impl ModuleResolver {
 
         // If name is provided, split it and append
         if let Some(name) = name
-            && !name.is_empty() {
-                let name_parts: Vec<&str> = name.split('.').collect();
-                current_parts.extend(name_parts.into_iter().map(|s| s.to_string()));
-            }
+            && !name.is_empty()
+        {
+            let name_parts: Vec<&str> = name.split('.').collect();
+            current_parts.extend(name_parts.into_iter().map(|s| s.to_string()));
+        }
 
         if current_parts.is_empty() {
             // If we're at the root after applying relative levels, return empty string
@@ -745,6 +746,30 @@ impl ModuleResolver {
         } else {
             Some(current_parts.join("."))
         }
+    }
+
+    /// Resolve a relative import given a package name (not path)
+    /// This is used when we have a package string like "foo.bar" instead of a file path
+    pub fn resolve_relative_import_from_package_name(
+        &self,
+        level: u32,
+        name: Option<&str>,
+        package_name: &str,
+    ) -> String {
+        let mut package_parts: Vec<&str> = package_name.split('.').collect();
+
+        // Go up 'level - 1' levels (one dot means current package)
+        if level > 1 && package_parts.len() >= (level as usize) - 1 {
+            package_parts.truncate(package_parts.len() - ((level as usize) - 1));
+        }
+
+        // Append the name part if provided
+        if let Some(name_part) = name
+            && !name_part.is_empty() {
+                package_parts.push(name_part);
+            }
+
+        package_parts.join(".")
     }
 
     /// Convert a filesystem path to module path components


### PR DESCRIPTION
## Summary
- Consolidates duplicate relative import resolution logic into a single method on ModuleResolver
- Improves separation of concerns by centralizing module resolution functionality
- Eliminates code duplication across three different implementations

## Changes
1. **Added `resolve_relative_to_absolute_module_name` method to ModuleResolver**
   - Centralizes the logic for converting relative imports to absolute module names
   - Handles all edge cases consistently (empty names, root-level imports, etc.)

2. **Extracted `path_to_module_parts` helper to ModuleResolver**
   - Moved from orchestrator.rs to resolver.rs where it logically belongs
   - This helper converts file paths to module name components

3. **Removed duplicate implementations**:
   - Removed `resolve_relative_import_with_context` from import_transformer.rs
   - Updated orchestrator.rs to use the new resolver method
   - Updated internal `resolve_relative_import` in resolver.rs to use the public method

4. **Added interior mutability for caching**:
   - Used RefCell for module_cache and classification_cache
   - Allows the resolver to be accessed through immutable references while still supporting caching
   - Methods that only read/cache data no longer require mutable self

5. **Updated all dependent code**:
   - Bundler now accepts a resolver reference
   - Import transformer uses immutable bundler references
   - All callers updated to use the centralized method

## Test plan
- [x] All existing tests pass
- [x] No functional changes - this is a pure refactoring
- [x] Verified relative import resolution still works correctly in test fixtures

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized relative import resolution through a dedicated resolver, improving consistency and reliability.
  * Transitioned internal structures to use immutable references with interior mutability, minimizing mutable access.
  * Unified module name resolution from file paths for better maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->