### PR TITLE
refactor: remove sort_wrapped_modules_by_dependencies wrapper function

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -12,7 +12,10 @@ use ruff_python_ast::{
 use ruff_text_size::TextRange;
 
 use crate::{
-    analyzers::{ImportAnalyzer, SymbolAnalyzer, namespace_analyzer::NamespaceAnalyzer},
+    analyzers::{
+        ImportAnalyzer, SymbolAnalyzer, dependency_analyzer::DependencyAnalyzer,
+        namespace_analyzer::NamespaceAnalyzer,
+    },
     ast_builder::{expressions, other, statements},
     code_generator::{
         circular_deps::SymbolDependencyGraph,
@@ -3344,7 +3347,6 @@ impl<'a> Bundler<'a> {
             // Sort wrapped modules by their dependencies to ensure correct initialization order
             // This is critical for namespace imports in circular dependencies
             debug!("Wrapped modules before sorting: {wrapped_modules_to_init:?}");
-            use crate::analyzers::dependency_analyzer::DependencyAnalyzer;
             let sorted_wrapped = DependencyAnalyzer::sort_wrapped_modules_by_dependencies(
                 wrapped_modules_to_init,
                 params.graph,

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1275,22 +1275,6 @@ impl<'a> Bundler<'a> {
         Ok(Vec::new()) // Statements are accumulated in ctx.inlined_stmts
     }
 
-    /// Sort wrapped modules by dependencies
-    fn sort_wrapped_modules_by_dependencies(
-        &self,
-        wrapped_modules: &[String],
-        _all_modules: &[(String, PathBuf, Vec<String>)],
-        graph: &DependencyGraph,
-    ) -> Vec<String> {
-        use crate::analyzers::dependency_analyzer::DependencyAnalyzer;
-
-        // Convert wrapped_modules slice to Vec for DependencyAnalyzer
-        let module_names: Vec<String> = wrapped_modules.to_vec();
-
-        // Use DependencyAnalyzer to sort
-        DependencyAnalyzer::sort_wrapped_modules_by_dependencies(module_names, graph)
-    }
-
     /// Get imports from entry module
     fn get_entry_module_imports(
         &self,
@@ -3360,9 +3344,9 @@ impl<'a> Bundler<'a> {
             // Sort wrapped modules by their dependencies to ensure correct initialization order
             // This is critical for namespace imports in circular dependencies
             debug!("Wrapped modules before sorting: {wrapped_modules_to_init:?}");
-            let sorted_wrapped = self.sort_wrapped_modules_by_dependencies(
-                &wrapped_modules_to_init,
-                params.sorted_modules,
+            use crate::analyzers::dependency_analyzer::DependencyAnalyzer;
+            let sorted_wrapped = DependencyAnalyzer::sort_wrapped_modules_by_dependencies(
+                wrapped_modules_to_init,
                 params.graph,
             );
             debug!("Wrapped modules after sorting: {sorted_wrapped:?}");

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1434,52 +1434,6 @@ impl<'a> Bundler<'a> {
         }
     }
 
-    /// Collect all Name expressions that a given expression depends on
-    fn collect_name_dependencies(expr: &Expr, deps: &mut FxIndexSet<String>) {
-        match expr {
-            Expr::Name(name) => {
-                deps.insert(name.id.to_string());
-            }
-            Expr::Attribute(attr) => {
-                Self::collect_name_dependencies(&attr.value, deps);
-            }
-            Expr::Call(call) => {
-                Self::collect_name_dependencies(&call.func, deps);
-                for arg in &call.arguments.args {
-                    Self::collect_name_dependencies(arg, deps);
-                }
-            }
-            Expr::BinOp(binop) => {
-                Self::collect_name_dependencies(&binop.left, deps);
-                Self::collect_name_dependencies(&binop.right, deps);
-            }
-            Expr::UnaryOp(unaryop) => {
-                Self::collect_name_dependencies(&unaryop.operand, deps);
-            }
-            Expr::List(list) => {
-                for item in &list.elts {
-                    Self::collect_name_dependencies(item, deps);
-                }
-            }
-            Expr::Tuple(tuple) => {
-                for item in &tuple.elts {
-                    Self::collect_name_dependencies(item, deps);
-                }
-            }
-            Expr::Dict(dict) => {
-                for item in &dict.items {
-                    if let Some(key) = &item.key {
-                        Self::collect_name_dependencies(key, deps);
-                    }
-                    Self::collect_name_dependencies(&item.value, deps);
-                }
-            }
-            _ => {
-                // For other expression types, we don't need to track dependencies
-            }
-        }
-    }
-
     /// Check if module has forward references that would cause NameError
     pub(crate) fn check_module_has_forward_references(
         &self,

--- a/crates/cribo/src/resolver.rs
+++ b/crates/cribo/src/resolver.rs
@@ -765,9 +765,10 @@ impl ModuleResolver {
 
         // Append the name part if provided
         if let Some(name_part) = name
-            && !name_part.is_empty() {
-                package_parts.push(name_part);
-            }
+            && !name_part.is_empty()
+        {
+            package_parts.push(name_part);
+        }
 
         package_parts.join(".")
     }


### PR DESCRIPTION
## Summary

This PR removes the unnecessary  wrapper function from Could not locate Gemfile and updates the callsite to use  directly.

## Changes

- Removed the wrapper function  from  (lines 1278-1292)
- Updated the callsite to call  directly
- Added the necessary import of  at the callsite
- Removed the unused  parameter from the call

## Motivation

This change simplifies the code by removing unnecessary indirection. The wrapper function was simply forwarding the call to  without adding any value.

## Test Results

- ✅ All tests pass (
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 75 tests
test analyzers::dependency_analyzer::tests::test_topological_sort_no_cycles ... ok
test analyzers::symbol_analyzer::tests::test_detect_hard_dependencies ... ok
test config::tests::test_target_version_configuration ... ok
test analyzers::import_analyzer::tests::test_find_directly_imported_modules ... ok
test analyzers::namespace_analyzer::tests::test_identify_required_namespaces ... ok
test analyzers::import_analyzer::tests::test_find_namespace_imported_modules ... ok
test analyzers::dependency_analyzer::tests::test_topological_sort_with_cycle ... ok
test analyzers::symbol_analyzer::tests::test_collect_global_symbols ... ok
test code_generator::circular_deps::tests::test_topological_sort_simple ... ok
test analyzers::import_analyzer::tests::test_find_directly_imported_modules_in_compound_statements ... ok
test cribo_graph::tests::test_circular_dependency_classification ... ok
test cribo_graph::tests::test_basic_module_graph ... ok
test cribo_graph::tests::test_circular_dependency_detection ... ok
test cribo_graph::tests::test_cloned_items_for_same_file ... ok
test config::tests::test_toml_config_loading ... ok
test config::tests::test_invalid_toml_config ... ok
test dirs::test::test_locate_system_config_xdg ... ok
test resolver::tests::test_path_canonicalization ... ok
test resolver::tests::test_classification ... ok
test resolver::tests::test_module_first_resolution ... ok
test visitors::export_collector::tests::test_dynamic_all ... ok
test tree_shaking::tests::test_basic_tree_shaking ... ok
test resolver::tests::test_package_resolution ... ok
test visitors::export_collector::tests::test_reexports ... ok
test visitors::export_collector::tests::test_simple_all_export ... ok
test visitors::export_collector::tests::test_tuple_all ... ok
test resolver::tests::test_namespace_package ... ok
test visitors::import_discovery::tests::test_class_method_import ... ok
test visitors::import_discovery::tests::test_conditional_import ... ok
test visitors::import_discovery::tests::test_function_scoped_import ... ok
test visitors::import_discovery::tests::test_importlib_static_discovery ... ok
test resolver::tests::test_directory_deduplication ... ok
test resolver::tests::test_entry_dir_first_in_search_path ... ok
test visitors::import_discovery::tests::test_module_level_import ... ok
test visitors::import_discovery::tests::test_nested_function_in_method_not_misclassified ... ok
test resolver::tests::test_pythonpath_module_discovery ... ok
test visitors::import_discovery::tests::test_relative_imports ... ok
test visitors::side_effect_detector::tests::test_annotation_side_effects ... ok
test visitors::side_effect_detector::tests::test_decorator_side_effects ... ok
test visitors::side_effect_detector::tests::test_imported_name_root_binding ... ok
test visitors::side_effect_detector::tests::test_default_argument_side_effects ... ok
test visitors::side_effect_detector::tests::test_lambda_assignment_has_side_effects ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_all_assignment ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_all_augmented_assignment ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_annotated_assignment_without_value ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_complex_literals ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_constant_expressions ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_docstring ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_safe_stdlib_import ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_all_method_calls ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_simple ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_simple_decorator ... ok
test visitors::side_effect_detector::tests::test_no_side_effects_simple_defaults ... ok
test visitors::side_effect_detector::tests::test_side_effects_annotated_assignment ... ok
test visitors::side_effect_detector::tests::test_side_effects_control_flow ... ok
test visitors::side_effect_detector::tests::test_side_effects_function_call ... ok
test visitors::side_effect_detector::tests::test_side_effects_imported_name ... ok
test visitors::side_effect_detector::tests::test_side_effects_in_assignment ... ok
test visitors::side_effect_detector::tests::test_side_effects_regular_augmented_assignment ... ok
test visitors::symbol_collector::tests::test_exports ... ok
test visitors::symbol_collector::tests::test_import_aliases ... ok
test visitors::symbol_collector::tests::test_symbol_collection_basic ... ok
test visitors::utils::tests::test_extract_string_list_from_list ... ok
test visitors::utils::tests::test_extract_string_list_with_non_literal ... ok
test visitors::variable_collector::tests::test_augmented_assignment ... ok
test visitors::variable_collector::tests::test_augmented_assignment_complex_targets ... ok
test resolver::tests::test_pythonpath_empty_or_nonexistent ... ok
test visitors::variable_collector::tests::test_deletion ... ok
test visitors::variable_collector::tests::test_global_declarations ... ok
test visitors::variable_collector::tests::test_static_collect_function_globals ... ok
test visitors::variable_collector::tests::test_nested_function_globals ... ok
test visitors::variable_collector::tests::test_variable_reads ... ok
test resolver::tests::test_pythonpath_multiple_directories ... ok
test resolver::tests::test_pythonpath_module_classification ... ok
test resolver::tests::test_relative_import_resolution ... ok

test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 1 test
test test_bundling_fixtures ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.12s


running 11 tests
test test_stdout_flag_help ... ok
test test_directory_entry_with_init_py_only ... ok
test test_directory_entry_empty_fails ... ok
test test_directory_entry_with_main_py ... ok
test test_missing_output_and_stdout_flags ... ok
test test_stdout_conflicts_with_output ... ok
test test_stdout_error_handling ... ok
test test_stdout_with_requirements ... ok
test test_stdout_with_verbose_separation ... ok
test test_stdout_mode_preserves_bundled_structure ... ok
test test_stdout_bundling_functionality ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 3 tests
test test_directory_entry_empty_dir_error ... ok
test test_directory_entry_init_py_fallback ... ok
test test_directory_entry_main_py_priority ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 1 test
test test_ecosystem_requests ... ignored, ecosystem test - run with --ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s)
- ✅ No clippy errors ()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure streamlined for improved maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->