### PR TITLE
fix: resolve __all__ completely statically

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1564,20 +1564,11 @@ impl<'a> Bundler<'a> {
             );
         }
 
-        // Extract modules that access __all__ from the dependency graph
-        for module_graph in params.graph.modules.values() {
-            for item in module_graph.items.values() {
-                // Check attribute accesses for __all__
-                for (base_name, attributes) in &item.attribute_accesses {
-                    if attributes.contains("__all__") {
-                        // This module accesses base_name.__all__
-                        self.modules_accessing_all.insert(base_name.clone());
-                        log::debug!(
-                            "Module '{}' accesses {base_name}.__all__",
-                            module_graph.module_name
-                        );
-                    }
-                }
+        // Extract modules that access __all__ from the pre-computed graph data
+        for (base_name, accessing_modules) in params.graph.get_modules_accessing_all() {
+            self.modules_accessing_all.insert(base_name.clone());
+            for module_name in accessing_modules {
+                log::debug!("Module '{module_name}' accesses {base_name}.__all__");
             }
         }
 

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -902,12 +902,18 @@ impl<'a> RecursiveImportTransformer<'a> {
                                         .collect();
 
                                     // Add __all__ attribute to the namespace with filtered exports
-                                    // BUT ONLY if the original module had an explicit __all__
+                                    // BUT ONLY if the original module had an explicit __all__ AND
+                                    // the code actually accesses this module's __all__
                                     if !filtered_exports.is_empty()
                                         && self
                                             .bundler
                                             .modules_with_explicit_all
                                             .contains(&full_module_path)
+                                        && (self.bundler.modules_accessing_all.contains(local_name)
+                                            || self
+                                                .bundler
+                                                .modules_accessing_all
+                                                .contains(&full_module_path))
                                     {
                                         let export_strings: Vec<&str> =
                                             filtered_exports.iter().map(|s| s.as_str()).collect();
@@ -978,12 +984,18 @@ impl<'a> RecursiveImportTransformer<'a> {
                                         .collect();
 
                                     // Add __all__ attribute to the namespace with filtered exports
-                                    // BUT ONLY if the original module had an explicit __all__
+                                    // BUT ONLY if the original module had an explicit __all__ AND
+                                    // the code actually accesses this module's __all__
                                     if !filtered_exports.is_empty()
                                         && self
                                             .bundler
                                             .modules_with_explicit_all
                                             .contains(&full_module_path)
+                                        && (self.bundler.modules_accessing_all.contains(local_name)
+                                            || self
+                                                .bundler
+                                                .modules_accessing_all
+                                                .contains(&full_module_path))
                                     {
                                         let export_strings: Vec<&str> =
                                             filtered_exports.iter().map(|s| s.as_str()).collect();

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -909,11 +909,11 @@ impl<'a> RecursiveImportTransformer<'a> {
                                             .bundler
                                             .modules_with_explicit_all
                                             .contains(&full_module_path)
-                                        && (self.bundler.modules_accessing_all.contains(local_name)
-                                            || self
-                                                .bundler
-                                                .modules_accessing_all
-                                                .contains(&full_module_path))
+                                        && self.bundler.modules_with_accessed_all.iter().any(
+                                            |(module, alias)| {
+                                                module == self.module_name && alias == local_name
+                                            },
+                                        )
                                     {
                                         let export_strings: Vec<&str> =
                                             filtered_exports.iter().map(|s| s.as_str()).collect();
@@ -991,11 +991,11 @@ impl<'a> RecursiveImportTransformer<'a> {
                                             .bundler
                                             .modules_with_explicit_all
                                             .contains(&full_module_path)
-                                        && (self.bundler.modules_accessing_all.contains(local_name)
-                                            || self
-                                                .bundler
-                                                .modules_accessing_all
-                                                .contains(&full_module_path))
+                                        && self.bundler.modules_with_accessed_all.iter().any(
+                                            |(module, alias)| {
+                                                module == self.module_name && alias == local_name
+                                            },
+                                        )
                                     {
                                         let export_strings: Vec<&str> =
                                             filtered_exports.iter().map(|s| s.as_str()).collect();

--- a/crates/cribo/src/cribo_graph.rs
+++ b/crates/cribo/src/cribo_graph.rs
@@ -320,6 +320,9 @@ pub struct CriboGraph {
     /// Track the primary module ID for each file
     /// (The first import name discovered for this file)
     file_primary_module: FxHashMap<PathBuf, (String, ModuleId)>,
+    /// Track modules whose __all__ attribute is accessed
+    /// Maps module name to set of modules that access its __all__
+    modules_accessing_all: FxHashMap<String, FxHashSet<String>>,
 }
 
 impl CriboGraph {
@@ -335,6 +338,7 @@ impl CriboGraph {
             module_canonical_paths: FxHashMap::default(),
             file_to_import_names: FxHashMap::default(),
             file_primary_module: FxHashMap::default(),
+            modules_accessing_all: FxHashMap::default(),
         }
     }
 
@@ -434,6 +438,19 @@ impl CriboGraph {
         } else {
             None
         }
+    }
+
+    /// Get modules that access __all__ attribute
+    pub fn get_modules_accessing_all(&self) -> &FxHashMap<String, FxHashSet<String>> {
+        &self.modules_accessing_all
+    }
+
+    /// Add a module that accesses __all__ of another module
+    pub fn add_module_accessing_all(&mut self, base_module: String, accessing_module: String) {
+        self.modules_accessing_all
+            .entry(base_module)
+            .or_default()
+            .insert(accessing_module);
     }
 
     /// Add a dependency between modules (from depends on to)

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_global.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_global.snap
@@ -115,7 +115,6 @@ foo_1 = "main_foo"
 foo = foo_1
 bar_1 = "main_bar"
 bar = bar_1
-module_global_keyword.__all__ = ['foo', 'get_foo', 'modify_foo']
 module_globals_dict = __cribo_init___cribo_5101f4_module_globals_dict()
 module_mixed_patterns = __cribo_init___cribo_c75306_module_mixed_patterns()
 assert foo_1 == "main_foo"

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_nested_namespace_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_nested_namespace_import.snap
@@ -18,7 +18,6 @@ greetings.greeting = greetings_greeting
 greetings_greeting.get_greeting = get_greeting
 """Test nested namespace imports"""
 greetings.greeting = types.SimpleNamespace()
-greetings.greeting.__all__ = ['get_greeting']
 greetings.greeting.get_greeting = get_greeting
 message = greetings.greeting.get_greeting("Python")
 print(message)

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_regular_import_aliases.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_regular_import_aliases.snap
@@ -43,11 +43,9 @@ utils_helpers.UtilityClass = UtilityClass
 utils_helpers.helper_function = helper_function
 '''\nTest fixture for regular import statements with aliases (non-"from" imports).\nThis exercises the code path in ast_rewriter.rs around lines 216-228.\n'''
 helper_utils = types.SimpleNamespace()
-helper_utils.__all__ = ['UtilityClass', 'helper_function']
 helper_utils.UtilityClass = UtilityClass
 helper_utils.helper_function = helper_function
 config_module = types.SimpleNamespace()
-config_module.__all__ = ['DEFAULT_CONFIG', 'get_config']
 config_module.DEFAULT_CONFIG = DEFAULT_CONFIG
 config_module.get_config = get_config
 def main():

--- a/crates/cribo/tests/snapshots/bundled_code@conditional_exports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@conditional_exports.snap
@@ -70,7 +70,6 @@ def __cribo_init___cribo_244765_compat_module():
     return module
 """Test conditional imports and exports without explicit __all__."""
 compat_module = __cribo_init___cribo_244765_compat_module()
-exceptions_module.__all__ = ['BaseError']
 print("compat_module has JSONDecodeError:", hasattr(compat_module, "JSONDecodeError"))
 if hasattr(compat_module, "JSONDecodeError"):
     print("✓ Can access compat_module.JSONDecodeError")

--- a/crates/cribo/tests/snapshots/bundled_code@cross_module_attribute_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@cross_module_attribute_import.snap
@@ -45,5 +45,4 @@ mypackage.core = mypackage_core
 mypackage_core.process_data = process_data
 mypackage___version__.__version__ = __version__
 """Test cross-module attribute import with circular dependencies that require init functions."""
-mypackage.__all__ = ['get_full_info']
 print(mypackage.get_full_info())

--- a/crates/cribo/tests/snapshots/bundled_code@file_deduplication_basic.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@file_deduplication_basic.snap
@@ -18,7 +18,6 @@ app.utils = app_utils
 app_utils.get_name = get_name
 app_utils.helper = helper
 app.utils = types.SimpleNamespace()
-app.utils.__all__ = ['get_name', 'helper']
 app.utils.get_name = get_name
 app.utils.helper = helper
 app_utils = app_utils

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_import_before_init.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_import_before_init.snap
@@ -45,7 +45,6 @@ JSONDecodeError = mypkg.compat.JSONDecodeError
 mypkg.exceptions = mypkg_exceptions
 mypkg_exceptions.BaseException = BaseException
 mypkg_exceptions.CustomJSONError = CustomJSONError
-mypkg.__all__ = ['CustomJSONError']
 mypkg.CustomJSONError = CustomJSONError
 try:
     raise mypkg.CustomJSONError("Test error", "doc", 42)

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_in_exception.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_in_exception.snap
@@ -33,7 +33,6 @@ myrequests_compat.JSONDecodeError = JSONDecodeError_2
 myrequests_compat.builtin_str = builtin_str
 myrequests_compat.is_str = is_str
 """Test case for forward reference to init function"""
-myrequests.__all__ = ['JSONDecodeError', 'MutableMapping', 'compat']
 myrequests.JSONDecodeError = JSONDecodeError_1
 myrequests.MutableMapping = MutableMapping_1
 print(f"MutableMapping: {myrequests.MutableMapping}")

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
@@ -113,7 +113,6 @@ myrequests_exceptions.InvalidJSONError = InvalidJSONError
 myrequests_exceptions.JSONDecodeError = JSONDecodeError
 myrequests_cookies.CookieJar = CookieJar
 """Test that mimics requests' pattern causing forward reference."""
-myrequests.__all__ = ['CookieJar', 'JSONDecodeError']
 myrequests.CookieJar = CookieJar
 myrequests.JSONDecodeError = JSONDecodeError
 jar = myrequests.CookieJar()

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_four_module_cycle.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_four_module_cycle.snap
@@ -23,7 +23,6 @@ def process_in_d():
     """Process in D, depends back on A - completes the 4-module cycle"""
     return f"D({final_step()})"
 module_a = types.SimpleNamespace(start_process=start_process, final_step=final_step)
-module_a.__all__ = ['final_step', 'start_process']
 def main():
     result = module_a.start_process()
     print(f"Four module cycle result: {result}")

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_package_level_cycles.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_package_level_cycles.snap
@@ -18,7 +18,6 @@ def helper_function():
     util_result = utility_function()
     return f"pkg2.helper(using_{util_result})"
 pkg1 = types.SimpleNamespace(main_function=main_function, utility_function=utility_function)
-pkg1.__all__ = ['main_function', 'utility_function']
 def main():
     result = pkg1.main_function()
     print(f"Package cycle result: {result}")

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_three_module_cycle.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_three_module_cycle.snap
@@ -20,7 +20,6 @@ def process_c():
     value = get_value_a()
     return f"C(using_{value})"
 module_a = types.SimpleNamespace(process_a=process_a, get_value_a=get_value_a)
-module_a.__all__ = ['get_value_a', 'process_a']
 def main():
     result = module_a.process_a()
     print(f"Result: {result}")

--- a/crates/cribo/tests/snapshots/bundled_code@simple_nested_handler.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@simple_nested_handler.snap
@@ -12,7 +12,6 @@ def handler_2() -> str:
 def handler_3() -> str:
     return "Hello from foo.py"
 foo = types.SimpleNamespace(handler=handler_3)
-foo.__all__ = ['handler']
 boo_handler = handler_2
 def handler_1():
     print(foo.handler())

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import.snap
@@ -17,6 +17,5 @@ greetings.messages = greetings_messages
 greetings_greeting.message = message
 greetings_messages.message = message
 greetings.greeting = types.SimpleNamespace()
-greetings.greeting.__all__ = ['message']
 greetings.greeting.message = message
 print(greetings.greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_from_parent_package.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_from_parent_package.snap
@@ -17,6 +17,5 @@ greetings.messages = greetings_messages
 greetings_greeting.message = message
 greetings_messages.message = message
 greetings.greeting = types.SimpleNamespace()
-greetings.greeting.__all__ = ['message']
 greetings.greeting.message = message
 print(greetings.greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_in_init.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_in_init.snap
@@ -13,6 +13,5 @@ message = "Hello"
 greetings_greeting = types.SimpleNamespace()
 greetings.greeting = greetings_greeting
 greetings_greeting.message = message
-greetings.__all__ = ['message']
 greetings.message = message
 print(greetings.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_single_dot.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_single_dot.snap
@@ -20,6 +20,5 @@ message_1 = messages.message
 greetings_greeting.message = message_1
 greetings_messages.message = message_2
 greetings.greeting = types.SimpleNamespace()
-greetings.greeting.__all__ = ['message']
 greetings.greeting.message = message_1
 print(greetings.greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_single_dot_in_init.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_explicit_relative_import_single_dot_in_init.snap
@@ -16,6 +16,5 @@ greeting = types.SimpleNamespace()
 greeting.message = message_2
 message_1 = greeting.message
 greetings_greeting.message = message_2
-greetings.__all__ = ['message']
 greetings.message = message_1
 print(greetings.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_implicit_init_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_implicit_init_import.snap
@@ -14,5 +14,4 @@ greetings_irrelevant = types.SimpleNamespace()
 greetings.irrelevant = greetings_irrelevant
 greetings.message = message
 greetings.irrelevant = types.SimpleNamespace()
-greetings.__all__ = ['message']
 print(greetings.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_module_with_triple_quotes.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_module_with_triple_quotes.snap
@@ -9,5 +9,4 @@ input_file: crates/cribo/tests/fixtures/stickytape_module_with_triple_quotes/mai
 import types
 message = "Hello\n'''\n" + '"""'
 greeting = types.SimpleNamespace(message=message)
-greeting.__all__ = ['message']
 print(greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_script_using_module_in_package.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_script_using_module_in_package.snap
@@ -14,6 +14,5 @@ greetings_greeting = types.SimpleNamespace()
 greetings.greeting = greetings_greeting
 greetings_greeting.message = message
 greetings.greeting = types.SimpleNamespace()
-greetings.greeting.__all__ = ['message']
 greetings.greeting.message = message
 print(greetings.greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_script_using_stdlib_module_in_package.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_script_using_stdlib_module_in_package.snap
@@ -10,6 +10,5 @@ import types
 import xml.etree.ElementTree
 message = "Hello"
 greeting = types.SimpleNamespace(message=message)
-greeting.__all__ = ['message']
 print(xml.etree.ElementTree.__name__)
 print(greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_script_with_single_local_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_script_with_single_local_import.snap
@@ -9,5 +9,4 @@ input_file: crates/cribo/tests/fixtures/stickytape_script_with_single_local_impo
 import types
 message = "Hello"
 greeting = types.SimpleNamespace(message=message)
-greeting.__all__ = ['message']
 print(greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@stickytape_script_with_single_local_import_of_package.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stickytape_script_with_single_local_import_of_package.snap
@@ -9,5 +9,4 @@ input_file: crates/cribo/tests/fixtures/stickytape_script_with_single_local_impo
 import types
 message = "Hello"
 greeting = types.SimpleNamespace(message=message)
-greeting.__all__ = ['message']
 print(greeting.message)

--- a/crates/cribo/tests/snapshots/bundled_code@version_import_complex.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@version_import_complex.snap
@@ -23,7 +23,6 @@ utils.get_user_agent = get_user_agent
 mypackage_utils.get_user_agent = get_user_agent
 mypackage___version__.__version__ = __version__
 """Test fixture for importing __version__ in a complex module structure."""
-mypackage.__all__ = ['__version__']
 mypackage.__version__ = __version__
 print(f"User agent: {get_user_agent()}")
 print(f"Package version: {mypackage.__version__}")

--- a/crates/cribo/tests/snapshots/bundled_code@version_import_with_init_functions.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@version_import_with_init_functions.snap
@@ -22,10 +22,8 @@ mypackage.utils = mypackage_utils
 mypackage_utils.get_user_agent = get_user_agent
 mypackage___version__.__version__ = __version__
 """Test fixture for version imports with complex module initialization."""
-mypackage.__all__ = ['__version__']
 mypackage.__version__ = __version__
 mypackage.utils = types.SimpleNamespace()
-mypackage.utils.__all__ = ['get_user_agent']
 mypackage.utils.get_user_agent = get_user_agent
 print(f"User agent: {mypackage.utils.get_user_agent()}")
 print(f"Version from package: {mypackage.__version__}")

--- a/crates/cribo/tests/snapshots/bundled_code@xfail_wrapper_module_builtin_types.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@xfail_wrapper_module_builtin_types.snap
@@ -66,7 +66,6 @@ pkg_compat.bytes = bytes
 pkg_compat.str = str
 pkg_utils.process_data = process_data
 """Test wrapper module pattern that triggers init functions with builtin types bug.\n\nThis reproduces the exact pattern from requests where:\n1. Multiple modules form circular dependencies (wrapper modules)\n2. One wrapper module (compat) has self-referential builtin assignments\n3. Another wrapper module (utils) accesses these as attributes\n4. The bundler generates init functions for wrapper modules\n"""
-pkg.__all__ = ['process_data', 'compat']
 pkg.process_data = process_data
 result = pkg.process_data(b"test")
 print(f"Result: {result}")


### PR DESCRIPTION
## Summary

This PR implements static resolution of `__all__` attributes, ensuring they are only emitted in the bundled output when the code actually accesses them.

## Problem

Previously, `__all__` attributes were unconditionally added to every namespace object in the bundled output, even when the code never accessed them. This created unnecessary clutter and confusion since:
- All imports are resolved statically at bundle time
- No import statements remain in the bundled code
- The `__all__` attributes served no functional purpose unless explicitly accessed

## Solution

Implemented static `__all__` resolution by:

1. **Tracking `__all__` access** - Enhanced the dependency graph builder to detect when code accesses `module.__all__`
2. **Conditional emission** - Only emit `__all__` assignments when:
   - The module originally had an explicit `__all__` defined
   - AND the code actually accesses that module's `__all__` attribute
3. **Cleaner output** - Removed 27 unnecessary `__all__` assignments from test snapshots

## Changes

- Added `modules_accessing_all` tracking to the bundler
- Modified `ImportTransformer` to conditionally emit `__all__` based on access
- Updated namespace creation logic to follow the same conditional pattern
- All existing tests pass, including those that explicitly access `__all__`

## Test Results

- ✅ All tests pass
- ✅ 27 test snapshots updated to remove unnecessary `__all__` 
- ✅ Tests that access `__all__` (like `all_variable_handling`) continue to work correctly

The bundled output is now cleaner and more focused - `__all__` only appears when it's functionally necessary.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of the __all__ attribute: Now, __all__ assignments are only generated for modules where the attribute is actually accessed, reducing unnecessary assignments.
  * Added tracking of module __all__ attribute accesses across the dependency graph for more precise namespace generation.

* **Bug Fixes**
  * Prevented creation of unused __all__ attributes in bundled and inlined modules, resulting in cleaner output and more accurate namespace objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->