### PR TITLE
refactor: fix clippy pedantic warnings for identical match arms

### DIFF
--- a/crates/cribo/src/analyzers/import_analyzer.rs
+++ b/crates/cribo/src/analyzers/import_analyzer.rs
@@ -143,8 +143,8 @@ impl ImportAnalyzer {
 
                 if Self::is_import_unused(&ctx) {
                     let module_name = match &import_data.item_type {
-                        crate::cribo_graph::ItemType::Import { module, .. } => module.clone(),
-                        crate::cribo_graph::ItemType::FromImport { module, .. } => module.clone(),
+                        crate::cribo_graph::ItemType::Import { module, .. }
+                        | crate::cribo_graph::ItemType::FromImport { module, .. } => module.clone(),
                         _ => continue,
                     };
 

--- a/crates/cribo/src/code_generator/expression_handlers.rs
+++ b/crates/cribo/src/code_generator/expression_handlers.rs
@@ -103,13 +103,15 @@ pub(super) fn expr_uses_importlib(expr: &Expr) -> bool {
                 || slice.upper.as_ref().is_some_and(|u| expr_uses_importlib(u))
                 || slice.step.as_ref().is_some_and(|s| expr_uses_importlib(s))
         }
-        // Literals don't use importlib
+        // Literals and other expressions that don't use importlib
         Expr::StringLiteral(_)
         | Expr::BytesLiteral(_)
         | Expr::NumberLiteral(_)
         | Expr::BooleanLiteral(_)
         | Expr::NoneLiteral(_)
-        | Expr::EllipsisLiteral(_) => false,
+        | Expr::EllipsisLiteral(_)
+        | Expr::IpyEscapeCommand(_) // IPython specific
+        | Expr::TString(_) => false, // Template strings
         // Check if any interpolated expressions in the f-string use importlib
         Expr::FString(fstring) => fstring.value.elements().any(|element| {
             if let ruff_python_ast::InterpolatedStringElement::Interpolation(expr_elem) = element {
@@ -118,10 +120,6 @@ pub(super) fn expr_uses_importlib(expr: &Expr) -> bool {
                 false
             }
         }),
-        // Match expressions not available in this ruff version
-        // Type expressions typically don't use importlib directly
-        Expr::IpyEscapeCommand(_) => false, // IPython specific
-        Expr::TString(_) => false,          // Template strings
     }
 }
 

--- a/crates/cribo/src/code_generator/import_deduplicator.rs
+++ b/crates/cribo/src/code_generator/import_deduplicator.rs
@@ -95,10 +95,14 @@ pub(super) fn stmt_uses_importlib(stmt: &Stmt) -> bool {
             .iter()
             .any(expression_handlers::expr_uses_importlib),
         // Statements that don't contain expressions
-        Stmt::Import(_) | Stmt::ImportFrom(_) => false, /* Already handled by import */
-        // transformation
-        Stmt::Pass(_) | Stmt::Break(_) | Stmt::Continue(_) => false,
-        Stmt::Global(_) | Stmt::Nonlocal(_) => false,
+        Stmt::Import(_)
+        | Stmt::ImportFrom(_) // Already handled by import transformation
+        | Stmt::Pass(_)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::Global(_)
+        | Stmt::Nonlocal(_)
+        | Stmt::IpyEscapeCommand(_) => false, // IPython specific, unlikely to use importlib
         // Match and TypeAlias need special handling
         Stmt::Match(match_stmt) => {
             expression_handlers::expr_uses_importlib(&match_stmt.subject)
@@ -108,7 +112,6 @@ pub(super) fn stmt_uses_importlib(stmt: &Stmt) -> bool {
                     .any(|case| case.body.iter().any(stmt_uses_importlib))
         }
         Stmt::TypeAlias(type_alias) => expression_handlers::expr_uses_importlib(&type_alias.value),
-        Stmt::IpyEscapeCommand(_) => false, // IPython specific, unlikely to use importlib
     }
 }
 

--- a/crates/cribo/src/code_generator/module_registry.rs
+++ b/crates/cribo/src/code_generator/module_registry.rs
@@ -131,14 +131,12 @@ pub fn get_synthetic_module_name(module_name: &str, content_hash: &str) -> Strin
 /// This is a simple character replacement - collision handling should be done by the caller
 pub fn sanitize_module_name_for_identifier(name: &str) -> String {
     name.chars()
-        .map(|c| match c {
-            // Replace common invalid characters with descriptive names
-            '-' => '_',
-            '.' => '_',
-            ' ' => '_',
-            // For other non-alphanumeric characters, replace with underscore
-            c if c.is_alphanumeric() || c == '_' => c,
-            _ => '_',
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
         })
         .collect::<String>()
 }

--- a/crates/cribo/src/code_generator/module_transformer.rs
+++ b/crates/cribo/src/code_generator/module_transformer.rs
@@ -913,6 +913,7 @@ fn transform_expr_for_module_vars(
             // TODO: Implement f-string transformation if needed
         }
         // Literals don't contain variable references
+        // Name expressions that don't match the conditional pattern (e.g., Store context)
         Expr::StringLiteral(_)
         | Expr::BytesLiteral(_)
         | Expr::NumberLiteral(_)
@@ -920,9 +921,8 @@ fn transform_expr_for_module_vars(
         | Expr::NoneLiteral(_)
         | Expr::EllipsisLiteral(_)
         | Expr::TString(_)
-        | Expr::IpyEscapeCommand(_) => {}
-        // Name expressions that don't match the conditional pattern (e.g., Store context)
-        Expr::Name(_) => {}
+        | Expr::IpyEscapeCommand(_)
+        | Expr::Name(_) => {}
     }
 }
 

--- a/crates/cribo/src/cribo_graph.rs
+++ b/crates/cribo/src/cribo_graph.rs
@@ -82,8 +82,7 @@ impl ItemType {
     /// Get the name of this item if it has one
     pub fn name(&self) -> Option<&str> {
         match self {
-            ItemType::FunctionDef { name } => Some(name),
-            ItemType::ClassDef { name } => Some(name),
+            ItemType::FunctionDef { name } | ItemType::ClassDef { name } => Some(name),
             _ => None,
         }
     }

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -815,10 +815,8 @@ impl BundleOrchestrator {
         let mut imports = Vec::new();
         for item_data in items.values() {
             match &item_data.item_type {
-                crate::cribo_graph::ItemType::Import { module, alias: _ } => {
-                    imports.push(module.clone());
-                }
-                crate::cribo_graph::ItemType::FromImport { module, .. } => {
+                crate::cribo_graph::ItemType::Import { module, .. }
+                | crate::cribo_graph::ItemType::FromImport { module, .. } => {
                     imports.push(module.clone());
                 }
                 _ => {}

--- a/crates/cribo/src/side_effects.rs
+++ b/crates/cribo/src/side_effects.rs
@@ -13,12 +13,9 @@ use crate::visitors::SideEffectDetector;
 pub fn is_safe_stdlib_module(module_name: &str) -> bool {
     match module_name {
         // Modules that modify global state - DO NOT HOIST
-        "antigravity" | "this" | "__hello__" | "__phello__" => false,
-        "site" | "sitecustomize" | "usercustomize" => false,
-        "readline" | "rlcompleter" => false,
-        "turtle" | "tkinter" => false,
-        "webbrowser" => false,
-        "platform" | "locale" => false,
+        "antigravity" | "this" | "__hello__" | "__phello__" | "site" | "sitecustomize"
+        | "usercustomize" | "readline" | "rlcompleter" | "turtle" | "tkinter" | "webbrowser"
+        | "platform" | "locale" => false,
 
         _ => {
             let root_module = module_name.split('.').next().unwrap_or(module_name);

--- a/crates/cribo/src/stdlib_normalization.rs
+++ b/crates/cribo/src/stdlib_normalization.rs
@@ -244,16 +244,32 @@ impl StdlibNormalizer {
         // Check if this is a stdlib module itself (not just an attribute)
         match module_path {
             // Known stdlib submodules that need separate imports
-            "http.cookiejar" | "http.cookies" | "http.server" | "http.client" => true,
-            "urllib.parse" | "urllib.request" | "urllib.response" | "urllib.error"
-            | "urllib.robotparser" => true,
-            "xml.etree" | "xml.etree.ElementTree" | "xml.dom" | "xml.sax" | "xml.parsers" => true,
-            "email.mime" | "email.parser" | "email.message" | "email.utils" => true,
-            "collections.abc" => true,
-            "concurrent.futures" => true,
-            "importlib.util" | "importlib.machinery" | "importlib.resources" => true,
-            "multiprocessing.pool" | "multiprocessing.managers" => true,
-            "os.path" => true,
+            "http.cookiejar"
+            | "http.cookies"
+            | "http.server"
+            | "http.client"
+            | "urllib.parse"
+            | "urllib.request"
+            | "urllib.response"
+            | "urllib.error"
+            | "urllib.robotparser"
+            | "xml.etree"
+            | "xml.etree.ElementTree"
+            | "xml.dom"
+            | "xml.sax"
+            | "xml.parsers"
+            | "email.mime"
+            | "email.parser"
+            | "email.message"
+            | "email.utils"
+            | "collections.abc"
+            | "concurrent.futures"
+            | "importlib.util"
+            | "importlib.machinery"
+            | "importlib.resources"
+            | "multiprocessing.pool"
+            | "multiprocessing.managers"
+            | "os.path" => true,
             _ => {
                 // For other cases, check if it's a known stdlib module
                 let root = module_path.split('.').next().unwrap_or(module_path);

--- a/crates/cribo/src/visitors/export_collector.rs
+++ b/crates/cribo/src/visitors/export_collector.rs
@@ -84,9 +84,7 @@ impl<'a> Visitor<'a> for ExportCollector {
                     self.has_dynamic_all = true;
                 }
             }
-            Stmt::ImportFrom(_) => {
-                // Import from statements - no processing needed
-            }
+            // Import from statements and other statements - no processing needed
             _ => {}
         }
 

--- a/crates/cribo/src/visitors/side_effect_detector.rs
+++ b/crates/cribo/src/visitors/side_effect_detector.rs
@@ -309,17 +309,9 @@ impl<'a> Visitor<'a> for SideEffectDetector {
             }
 
             // Import statements are handled separately by the bundler
-            Stmt::Import(_) | Stmt::ImportFrom(_) => {
-                return; // Don't call walk_stmt
-            }
-
             // Type alias statements are safe
-            Stmt::TypeAlias(_) => {
-                return; // Don't call walk_stmt
-            }
-
             // Pass statements are no-ops
-            Stmt::Pass(_) => {
+            Stmt::Import(_) | Stmt::ImportFrom(_) | Stmt::TypeAlias(_) | Stmt::Pass(_) => {
                 return; // Don't call walk_stmt
             }
 
@@ -358,23 +350,7 @@ impl<'a> Visitor<'a> for SideEffectDetector {
                 return; // Don't walk further
             }
 
-            // These are definitely side effects
-            Stmt::If(_)
-            | Stmt::While(_)
-            | Stmt::For(_)
-            | Stmt::With(_)
-            | Stmt::Match(_)
-            | Stmt::Raise(_)
-            | Stmt::Try(_)
-            | Stmt::Assert(_)
-            | Stmt::Global(_)
-            | Stmt::Nonlocal(_)
-            | Stmt::Delete(_) => {
-                self.has_side_effects = true;
-                return;
-            }
-
-            // Any other statement type is considered a side effect
+            // These are definitely side effects (including any other statement type)
             _ => {
                 self.has_side_effects = true;
                 return;
@@ -420,12 +396,10 @@ impl<'a> Visitor<'a> for SideEffectDetector {
 
                 // Attribute access is only a side effect if the base object might have side effects
                 // For now, we'll walk into it to check if the base has side effects
-                Expr::Attribute(_) => {
-                    // Continue walking to check the base object
-                }
-
                 // For other expressions, continue walking to check nested expressions
-                _ => {}
+                _ => {
+                    // Continue walking to check the base object/nested expressions
+                }
             }
         }
 

--- a/crates/cribo/tests/test_bundling_snapshots.rs
+++ b/crates/cribo/tests/test_bundling_snapshots.rs
@@ -254,7 +254,9 @@ fn test_bundling_fixtures() {
                 );
             }
             // pyfail_: Expected to fail, and it did - good!
-            (false, true, _) => {
+            // xfail_: Python succeeded, will check bundling failure later
+            // Normal fixture: Succeeded as expected
+            (false, true, _) | (true, false, true | false) => {
                 // Continue to bundling
             }
             // xfail_: Python execution MUST succeed (only bundling should fail)
@@ -272,10 +274,6 @@ fn test_bundling_fixtures() {
                     stderr.trim()
                 );
             }
-            // xfail_: Python succeeded, will check bundling failure later
-            (true, false, true) => {
-                // Continue to bundling
-            }
             // Normal fixture: MUST succeed in Python execution
             (false, false, false) => {
                 let stderr = String::from_utf8_lossy(&original_output.stderr);
@@ -289,10 +287,6 @@ fn test_bundling_fixtures() {
                     stdout.trim(),
                     stderr.trim()
                 );
-            }
-            // Normal fixture: Succeeded as expected
-            (true, false, false) => {
-                // Continue to bundling
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes all `clippy::match_same_arms` warnings that were reported when running clippy with pedantic lints enabled.

## Changes

- Combined match arms with identical bodies using the `|` pattern
- Simplified match expressions where multiple arms return the same value  
- Avoided wildcard patterns in OR patterns to prevent additional warnings
- Improved code readability by eliminating redundant match arm implementations

## Test Results

- ✅ All tests pass (`cargo test --workspace`)
- ✅ No clippy warnings (`cargo clippy --workspace --all-targets`)
- ✅ No pedantic warnings for identical match arms (`cargo clippy --workspace --all-targets -- -W clippy::pedantic`)

## Files Changed

The changes touch multiple files across the codebase where match expressions had redundant arms:
- `import_analyzer.rs` - Combined Import/FromImport arms
- `expression_handlers.rs` - Combined literal expression arms
- `import_deduplicator.rs` - Combined statement arms that don't use importlib
- `module_registry.rs` - Simplified character replacement logic
- `module_transformer.rs` - Combined literal and name expression arms
- `cribo_graph.rs` - Combined FunctionDef/ClassDef name extraction
- `orchestrator.rs` - Combined Import/FromImport module extraction
- `side_effects.rs` - Combined unsafe stdlib modules
- `stdlib_normalization.rs` - Combined known stdlib submodules
- `export_collector.rs` - Simplified default match arm
- `side_effect_detector.rs` - Simplified side effect detection patterns
- `test_bundling_snapshots.rs` - Combined test fixture validation arms

🤖 Generated with [Claude Code](https://claude.ai/code)