### PR TITLE
fix: resolve clippy pedantic warnings for pass-by-value arguments

### DIFF
--- a/crates/cribo/benches/bundling.rs
+++ b/crates/cribo/benches/bundling.rs
@@ -138,13 +138,13 @@ fn benchmark_dependency_graph(c: &mut Criterion) {
             let mut graph = CriboGraph::new();
 
             // Add modules
-            let main_id = graph.add_module("main".to_string(), PathBuf::from("main.py"));
+            let main_id = graph.add_module("main".to_string(), &PathBuf::from("main.py"));
             let utils_id = graph.add_module(
                 "utils.helpers".to_string(),
-                PathBuf::from("utils/helpers.py"),
+                &PathBuf::from("utils/helpers.py"),
             );
             let models_id =
-                graph.add_module("models.user".to_string(), PathBuf::from("models/user.py"));
+                graph.add_module("models.user".to_string(), &PathBuf::from("models/user.py"));
 
             // Add dependencies - main depends on utils and models
             graph.add_module_dependency(main_id, utils_id);

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -7490,7 +7490,7 @@ impl Bundler<'_> {
 
                 // Add initialization statements after global declarations
                 if !added_init && !init_stmts.is_empty() {
-                    new_body.extend(init_stmts.iter().cloned());
+                    new_body.extend_from_slice(init_stmts);
                     added_init = true;
                 }
             } else {

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -65,6 +65,7 @@ pub struct RecursiveImportTransformer<'a> {
 
 impl<'a> RecursiveImportTransformer<'a> {
     /// Create a new transformer from parameters
+    #[allow(clippy::needless_pass_by_value)] // params contains mutable references
     pub fn new(params: RecursiveImportTransformerParams<'a>) -> Self {
         Self {
             bundler: params.bundler,
@@ -2214,7 +2215,7 @@ fn rewrite_import_from(
             log::debug!("Module '{module_name}' is a wrapper module in module_registry");
             // This is a wrapper module, we need to transform it
             return bundler.transform_bundled_import_from_multiple_with_current_module(
-                import_from,
+                &import_from,
                 &module_name,
                 inside_wrapper_init,
                 Some(current_module),
@@ -2249,7 +2250,7 @@ fn rewrite_import_from(
             absolute_import.module = Some(Identifier::new(&module_name, TextRange::default()));
         }
         bundler.transform_bundled_import_from_multiple_with_current_module(
-            absolute_import,
+            &absolute_import,
             &module_name,
             inside_wrapper_init,
             Some(current_module),
@@ -2277,7 +2278,7 @@ fn rewrite_import_from(
         );
         #[allow(clippy::too_many_arguments)]
         crate::code_generator::module_registry::create_assignments_for_inlined_imports(
-            import_from,
+            &import_from,
             &module_name,
             symbol_renames,
             &bundler.module_registry,

--- a/crates/cribo/src/code_generator/module_registry.rs
+++ b/crates/cribo/src/code_generator/module_registry.rs
@@ -220,7 +220,7 @@ pub fn create_reassignment(original_name: &str, renamed_name: &str) -> Stmt {
 /// Create assignments for inlined imports
 #[allow(clippy::too_many_arguments)]
 pub fn create_assignments_for_inlined_imports(
-    import_from: StmtImportFrom,
+    import_from: &StmtImportFrom,
     module_name: &str,
     symbol_renames: &FxIndexMap<String, FxIndexMap<String, String>>,
     module_registry: &FxIndexMap<String, String>,

--- a/crates/cribo/src/code_generator/module_transformer.rs
+++ b/crates/cribo/src/code_generator/module_transformer.rs
@@ -34,7 +34,7 @@ use crate::{
 /// Transforms a module AST into an initialization function
 pub fn transform_module_to_init_function<'a>(
     bundler: &'a Bundler<'a>,
-    ctx: ModuleTransformContext,
+    ctx: &ModuleTransformContext,
     mut ast: ModModule,
     symbol_renames: &FxIndexMap<String, FxIndexMap<String, String>>,
 ) -> Result<Stmt> {
@@ -210,7 +210,7 @@ pub fn transform_module_to_init_function<'a>(
         };
 
         if let Some(module_id) = module_id {
-            if let Some(module_info) = semantic_bundler.get_module_info(&module_id) {
+            if let Some(module_info) = semantic_bundler.get_module_info(module_id) {
                 debug!(
                     "Found module-scope symbols for '{}': {:?}",
                     ctx.module_name, module_info.module_scope_symbols
@@ -399,7 +399,7 @@ pub fn transform_module_to_init_function<'a>(
 
                     // Use actual module-level variables if available, but filter to only
                     // exported ones
-                    let module_level_vars = get_exported_module_vars(bundler, &ctx);
+                    let module_level_vars = get_exported_module_vars(bundler, ctx);
 
                     // Special handling for assignments involving built-in types
                     // We need to transform any reference to a built-in that will be assigned
@@ -476,7 +476,7 @@ pub fn transform_module_to_init_function<'a>(
 
                     // Use actual module-level variables if available, but filter to only exported
                     // ones
-                    let module_level_vars = get_exported_module_vars(bundler, &ctx);
+                    let module_level_vars = get_exported_module_vars(bundler, ctx);
 
                     // Transform references to built-ins that will be shadowed
                     if let Some(ref mut value) = ann_assign_clone.value {

--- a/crates/cribo/src/cribo_graph.rs
+++ b/crates/cribo/src/cribo_graph.rs
@@ -344,7 +344,7 @@ impl CriboGraph {
     /// Add a new module to the graph
     pub fn add_module(&mut self, name: String, path: &Path) -> ModuleId {
         // Always work with canonical paths
-        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_owned());
 
         // Check if this exact import name already exists
         if let Some(&existing_id) = self.module_names.get(&name) {

--- a/crates/cribo/src/semantic_bundler.rs
+++ b/crates/cribo/src/semantic_bundler.rs
@@ -411,9 +411,9 @@ impl SymbolRegistry {
     }
 
     /// Get rename for a symbol if it exists
-    pub fn get_rename(&self, module_id: &ModuleId, original: &str) -> Option<&str> {
+    pub fn get_rename(&self, module_id: ModuleId, original: &str) -> Option<&str> {
         self.renames
-            .get(&(*module_id, original.to_string()))
+            .get(&(module_id, original.to_string()))
             .map(std::string::String::as_str)
     }
 }
@@ -568,8 +568,8 @@ impl SemanticBundler {
     }
 
     /// Get module semantic info
-    pub fn get_module_info(&self, module_id: &ModuleId) -> Option<&ModuleSemanticInfo> {
-        self.module_semantics.get(module_id)
+    pub fn get_module_info(&self, module_id: ModuleId) -> Option<&ModuleSemanticInfo> {
+        self.module_semantics.get(&module_id)
     }
 
     /// Get symbol registry

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -936,7 +936,7 @@ mod tests {
         // Create a simple module with used and unused functions
         let module_id = graph.add_module(
             "test_module".to_string(),
-            std::path::PathBuf::from("test.py"),
+            &std::path::PathBuf::from("test.py"),
         );
         let module = graph
             .modules
@@ -983,7 +983,7 @@ mod tests {
 
         // Add entry module that uses only used_func
         let entry_id =
-            graph.add_module("__main__".to_string(), std::path::PathBuf::from("main.py"));
+            graph.add_module("__main__".to_string(), &std::path::PathBuf::from("main.py"));
         let entry = graph
             .modules
             .get_mut(&entry_id)

--- a/crates/cribo/src/util.rs
+++ b/crates/cribo/src/util.rs
@@ -34,7 +34,7 @@ pub fn module_name_from_relative(relative_path: &Path) -> Option<String> {
 
 /// Normalize line endings to LF (\n) for cross-platform consistency
 /// This ensures reproducible builds regardless of the platform where bundling occurs
-pub fn normalize_line_endings(content: String) -> String {
+pub fn normalize_line_endings(content: &str) -> String {
     // Replace Windows CRLF (\r\n) and Mac CR (\r) with Unix LF (\n)
     content
         .cow_replace("\r\n", "\n")


### PR DESCRIPTION
## Summary

This PR fixes all clippy pedantic warnings related to "argument is passed by value, but not consumed in the function body". These warnings were preventing CI from passing.

## Changes

### Pass-by-reference improvements (for large types):
- `StmtImportFrom` → `&StmtImportFrom` (2 instances)
- `BundleParams` → `&BundleParams`
- `Vec<Stmt>` → `&[Stmt]` (using slice instead of owned vector)
- `PathBuf` → `&Path` (more idiomatic)
- `Option<String>` → `&Option<String>`
- `StaticBundleParams` → `&StaticBundleParams`
- `ModuleTransformContext` → `&ModuleTransformContext` (2 instances)
- `String` → `&str` in `normalize_line_endings`

### Pass-by-value improvements (for small Copy types):
- `&self` → `self` for `ModuleId::as_u32()` (4 bytes, Copy type)
- `&ModuleId` → `ModuleId` in `get_rename()` and `get_module_info()` (4 bytes, Copy type)

### Special cases:
- Added `#[allow(clippy::needless_pass_by_value)]` for `RecursiveImportTransformer::new()` because the struct contains mutable references and cannot be passed by reference

### Additional fixes:
- Fixed needless_borrow warnings that appeared after the above changes
- Added missing `use std::path::Path` import

## Test Results

✅ All tests pass
✅ 0 clippy warnings (previously had 13+ warnings)
✅ No functional changes - only parameter passing improvements

## Performance Impact

These changes improve performance by:
- Avoiding unnecessary cloning of large structures
- Reducing stack usage for function calls
- Using more efficient parameter passing for small Copy types

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency and consistency by updating various functions and methods to accept references instead of owned values, reducing unnecessary cloning and copying.
  * Updated method and function signatures across modules to reflect reference-based argument passing.
  * Minor internal API adjustments for improved ergonomics and performance.

* **Style**
  * Added an attribute to suppress a Clippy warning in the import transformer.

No changes to user-facing features or documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->