### PR TITLE
refactor: extract module inlining logic into dedicated inliner module

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,8 @@ Entry Point → Orchestrator → Analyzers → Code Generator → Bundled Output
    - `namespace_analyzer.rs`: Detects namespace requirements
 
 3. **`code_generator/`** (Transformation Engine)
-   - `bundler.rs`: Main orchestration (72k tokens!)
+   - `bundler.rs`: Main orchestration
+   - `inliner.rs`: Module inlining logic for functions, classes, and assignments
    - `module_transformer.rs`: Module-level AST transformations
    - `expression_handlers.rs`: Creates/analyzes/transforms expressions
    - `namespace_manager.rs`: Manages namespace objects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ The project is organized as a Rust workspace with the main crate in `crates/crib
    - **Types** (`types.rs`): Shared types for analysis results
 
 3. **Code Generation** (`code_generator/` directory)
-   - **Bundler** (`bundler.rs`): Main orchestration for code generation (~67k tokens)
+   - **Bundler** (`bundler.rs`): Main orchestration for code generation
+   - **Inliner** (`inliner.rs`): Module inlining logic for functions, classes, and assignments
    - **Module Transformer** (`module_transformer.rs`): Module-level AST transformations
    - **Import Transformer** (`import_transformer.rs`): Import rewriting and resolution
    - **Expression Handlers** (`expression_handlers.rs`): Expression creation, analysis, and transformation

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -2374,7 +2374,7 @@ impl<'a> Bundler<'a> {
         // namespace hybrids
         let inlining_result = super::inliner::inline_all_modules(
             self,
-            inlinable_modules.clone(),
+            &inlinable_modules,
             &module_exports_map,
             &mut symbol_renames,
             &mut global_symbols,

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::excessive_nesting)]
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use log::debug;
@@ -25,9 +25,7 @@ use crate::{
         },
         expression_handlers, import_deduplicator,
         import_transformer::{RecursiveImportTransformer, RecursiveImportTransformerParams},
-        module_registry::{
-            INIT_RESULT_VAR, generate_unique_name, sanitize_module_name_for_identifier,
-        },
+        module_registry::{INIT_RESULT_VAR, sanitize_module_name_for_identifier},
         namespace_manager,
     },
     cribo_graph::CriboGraph as DependencyGraph,
@@ -1019,7 +1017,7 @@ impl<'a> Bundler<'a> {
     }
 
     /// Build a map of imported symbols to their source modules by analyzing import statements
-    fn build_import_source_map(
+    pub(crate) fn build_import_source_map(
         &self,
         statements: &[Stmt],
         module_name: &str,
@@ -1052,239 +1050,6 @@ impl<'a> Bundler<'a> {
         }
 
         import_sources
-    }
-
-    /// Inline a module
-    pub fn inline_module(
-        &mut self,
-        module_name: &str,
-        mut ast: ModModule,
-        module_path: &Path,
-        ctx: &mut InlineContext,
-    ) -> Result<Vec<Stmt>> {
-        let mut module_renames = FxIndexMap::default();
-
-        // Apply hard dependency rewriting BEFORE import transformation
-        if !self.hard_dependencies.is_empty() && self.circular_modules.contains(module_name) {
-            self.rewrite_hard_dependencies_in_module(&mut ast, module_name);
-        }
-
-        // Then apply recursive import transformation to the module
-        let mut transformer = RecursiveImportTransformer::new(RecursiveImportTransformerParams {
-            bundler: self,
-            module_name,
-            module_path: Some(module_path),
-            symbol_renames: ctx.module_renames,
-            deferred_imports: ctx.deferred_imports,
-            is_entry_module: false, // This is not the entry module
-            is_wrapper_init: false, // Not a wrapper init
-            global_deferred_imports: Some(&self.global_deferred_imports), // Pass global registry
-        });
-        transformer.transform_module(&mut ast);
-
-        // Copy import aliases from the transformer to the inline context
-        ctx.import_aliases = transformer.import_aliases;
-
-        // Reorder statements to ensure proper declaration order
-        let statements = if self.circular_modules.contains(module_name) {
-            self.reorder_statements_for_circular_module(module_name, ast.body, ctx.python_version)
-        } else {
-            // Even for non-circular modules, ensure module-level variables are declared
-            // before functions that might use them
-            self.reorder_statements_for_proper_declaration_order(ast.body)
-        };
-
-        // Build a map of imported symbols to their source modules
-        ctx.import_sources = self.build_import_source_map(&statements, module_name);
-
-        // Process each statement in the module
-        for stmt in statements {
-            match &stmt {
-                Stmt::Import(import_stmt) => {
-                    // Imports have already been transformed by RecursiveImportTransformer
-                    // Include them in the inlined output
-                    if !import_deduplicator::is_hoisted_import(self, &stmt) {
-                        log::debug!(
-                            "Including non-hoisted import in inlined module '{}': {:?}",
-                            module_name,
-                            import_stmt
-                                .names
-                                .iter()
-                                .map(|a| (
-                                    a.name.as_str(),
-                                    a.asname.as_ref().map(ruff_python_ast::Identifier::as_str)
-                                ))
-                                .collect::<Vec<_>>()
-                        );
-                        ctx.inlined_stmts.push(stmt.clone());
-                    }
-                }
-                Stmt::ImportFrom(_) => {
-                    // Imports have already been transformed by RecursiveImportTransformer
-                    // Include them in the inlined output
-                    if !import_deduplicator::is_hoisted_import(self, &stmt) {
-                        ctx.inlined_stmts.push(stmt.clone());
-                    }
-                }
-                Stmt::FunctionDef(func_def) => {
-                    let func_name = func_def.name.to_string();
-                    if !self.should_inline_symbol(&func_name, module_name, ctx.module_exports_map) {
-                        continue;
-                    }
-
-                    // Check if this symbol was renamed by semantic analysis
-                    let renamed_name = if let Some(module_rename_map) =
-                        ctx.module_renames.get(module_name)
-                    {
-                        if let Some(new_name) = module_rename_map.get(&func_name) {
-                            // Only use semantic rename if it's actually different
-                            if new_name == &func_name {
-                                // Semantic rename is same as original, check if there's a conflict
-                                if ctx.global_symbols.contains(&func_name) {
-                                    // There's a conflict, apply module suffix pattern
-                                    let base_name = self.get_unique_name_with_module_suffix(
-                                        &func_name,
-                                        module_name,
-                                    );
-                                    generate_unique_name(&base_name, ctx.global_symbols)
-                                } else {
-                                    // No conflict, use original name
-                                    func_name.clone()
-                                }
-                            } else {
-                                log::debug!(
-                                    "Using semantic rename for '{func_name}' to '{new_name}' in \
-                                     module '{module_name}'"
-                                );
-                                new_name.clone()
-                            }
-                        } else {
-                            // No semantic rename, check if there's a conflict
-                            if ctx.global_symbols.contains(&func_name) {
-                                // There's a conflict, apply module suffix pattern
-                                let base_name = self
-                                    .get_unique_name_with_module_suffix(&func_name, module_name);
-                                generate_unique_name(&base_name, ctx.global_symbols)
-                            } else {
-                                // No conflict, use original name
-                                func_name.clone()
-                            }
-                        }
-                    } else {
-                        // No semantic rename, check if there's a conflict
-                        if ctx.global_symbols.contains(&func_name) {
-                            // There's a conflict, apply module suffix pattern
-                            let base_name =
-                                self.get_unique_name_with_module_suffix(&func_name, module_name);
-                            generate_unique_name(&base_name, ctx.global_symbols)
-                        } else {
-                            // No conflict, use original name
-                            func_name.clone()
-                        }
-                    };
-
-                    // Always track the symbol mapping, even if not renamed
-                    module_renames.insert(func_name.clone(), renamed_name.clone());
-                    ctx.global_symbols.insert(renamed_name.clone());
-
-                    // Clone and rename the function
-                    let mut func_def_clone = func_def.clone();
-                    func_def_clone.name = Identifier::new(renamed_name, TextRange::default());
-
-                    // Apply renames to function annotations (parameters and return type)
-                    if let Some(ref mut returns) = func_def_clone.returns {
-                        expression_handlers::resolve_import_aliases_in_expr(
-                            returns,
-                            &ctx.import_aliases,
-                        );
-                        expression_handlers::rewrite_aliases_in_expr(returns, &module_renames);
-                    }
-
-                    // Apply renames to parameter annotations
-                    for param in &mut func_def_clone.parameters.args {
-                        if let Some(ref mut annotation) = param.parameter.annotation {
-                            expression_handlers::resolve_import_aliases_in_expr(
-                                annotation,
-                                &ctx.import_aliases,
-                            );
-                            expression_handlers::rewrite_aliases_in_expr(
-                                annotation,
-                                &module_renames,
-                            );
-                        }
-                    }
-
-                    // First resolve import aliases in function body
-                    for body_stmt in &mut func_def_clone.body {
-                        Self::resolve_import_aliases_in_stmt(body_stmt, &ctx.import_aliases);
-                    }
-
-                    // Create a temporary statement to rewrite the entire function properly
-                    let mut temp_stmt = Stmt::FunctionDef(func_def_clone);
-
-                    // Apply renames to the entire function (this will handle global statements
-                    // correctly)
-                    expression_handlers::rewrite_aliases_in_stmt(&mut temp_stmt, &module_renames);
-
-                    // Also apply semantic renames from context
-                    if let Some(semantic_renames) = ctx.module_renames.get(module_name) {
-                        expression_handlers::rewrite_aliases_in_stmt(
-                            &mut temp_stmt,
-                            semantic_renames,
-                        );
-                    }
-
-                    ctx.inlined_stmts.push(temp_stmt);
-                }
-                Stmt::ClassDef(class_def) => {
-                    self.inline_class(class_def, module_name, &mut module_renames, ctx);
-                }
-                Stmt::Assign(assign) => {
-                    self.inline_assignment(assign, module_name, &mut module_renames, ctx);
-                }
-                Stmt::AnnAssign(ann_assign) => {
-                    self.inline_ann_assignment(ann_assign, module_name, &mut module_renames, ctx);
-                }
-                // TypeAlias statements are safe metadata definitions
-                Stmt::TypeAlias(_) => {
-                    // Type aliases don't need renaming in Python, they're just metadata
-                    ctx.inlined_stmts.push(stmt);
-                }
-                // Pass statements are no-ops and safe
-                Stmt::Pass(_) => {
-                    // Pass statements can be included as-is
-                    ctx.inlined_stmts.push(stmt);
-                }
-                // Expression statements that are string literals are docstrings
-                Stmt::Expr(expr_stmt) => {
-                    if matches!(expr_stmt.value.as_ref(), Expr::StringLiteral(_)) {
-                        // This is a docstring - safe to include
-                        ctx.inlined_stmts.push(stmt);
-                    } else {
-                        // Other expression statements shouldn't exist in side-effect-free modules
-                        log::warn!(
-                            "Unexpected expression statement in side-effect-free module \
-                             '{module_name}': {stmt:?}"
-                        );
-                    }
-                }
-                _ => {
-                    // Any other statement type that we haven't explicitly handled
-                    log::warn!(
-                        "Unexpected statement type in side-effect-free module '{module_name}': \
-                         {stmt:?}"
-                    );
-                }
-            }
-        }
-
-        // Store the renames for this module
-        if !module_renames.is_empty() {
-            ctx.module_renames
-                .insert(module_name.to_string(), module_renames);
-        }
-
-        Ok(Vec::new()) // Statements are accumulated in ctx.inlined_stmts
     }
 
     /// Get imports from entry module
@@ -2607,147 +2372,16 @@ impl<'a> Bundler<'a> {
         // Inline the inlinable modules FIRST to populate symbol_renames
         // This ensures we know what symbols have been renamed before processing wrapper modules and
         // namespace hybrids
-        let mut all_deferred_imports = Vec::new();
-        let mut all_inlined_stmts = Vec::new(); // Collect all inlined statements first
-
-        for (module_name, ast, _module_path, _content_hash) in &inlinable_modules {
-            log::debug!("Inlining module '{module_name}'");
-
-            let mut inlined_stmts = Vec::new();
-            let mut deferred_imports = Vec::new();
-            let mut inline_ctx = InlineContext {
-                module_exports_map: &module_exports_map,
-                global_symbols: &mut global_symbols,
-                module_renames: &mut symbol_renames,
-                inlined_stmts: &mut inlined_stmts,
-                import_aliases: FxIndexMap::default(),
-                deferred_imports: &mut deferred_imports,
-                import_sources: FxIndexMap::default(),
-                python_version,
-            };
-            self.inline_module(module_name, ast.clone(), _module_path, &mut inline_ctx)?;
-            log::debug!(
-                "Inlined {} statements from module '{}'",
-                inlined_stmts.len(),
-                module_name
-            );
-            all_inlined_stmts.extend(inlined_stmts); // Collect instead of adding to final_body
-            // Note: We don't track deferred imports globally anymore since we don't use sys.modules
-
-            // Filter deferred imports to avoid conflicts
-            // If an inlined module imports a symbol but doesn't export it,
-            // and that symbol would conflict with other imports, skip it
-            for stmt in deferred_imports {
-                let should_include = if let Stmt::Assign(assign) = &stmt {
-                    if let [Expr::Name(target)] = assign.targets.as_slice()
-                        && let Expr::Name(_value) = &*assign.value
-                    {
-                        let symbol_name = target.id.as_str();
-
-                        // Check if this module exports the symbol
-                        let exports_symbol =
-                            if let Some(Some(exports)) = module_exports_map.get(module_name) {
-                                exports.contains(&symbol_name.to_string())
-                            } else {
-                                // No explicit __all__, check if it's a module-level definition
-                                // For now, assume it's not exported if there's no __all__
-                                false
-                            };
-
-                        if exports_symbol {
-                            true
-                        } else {
-                            // Check if this would conflict with existing deferred imports
-                            let has_conflict = all_deferred_imports.iter().any(|existing| {
-                                if let Stmt::Assign(existing_assign) = existing
-                                    && let [Expr::Name(existing_target)] =
-                                        existing_assign.targets.as_slice()
-                                {
-                                    existing_target.id.as_str() == symbol_name
-                                } else {
-                                    false
-                                }
-                            });
-
-                            if has_conflict {
-                                log::debug!(
-                                    "Skipping deferred import '{symbol_name}' from module \
-                                     '{module_name}' due to conflict"
-                                );
-                                false
-                            } else {
-                                true
-                            }
-                        }
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                };
-
-                if should_include {
-                    // Check if this deferred import already exists in all_deferred_imports
-                    let is_duplicate = if let Stmt::Assign(assign) = &stmt {
-                        if let Expr::Name(target) = &assign.targets[0] {
-                            let target_name = target.id.as_str();
-
-                            // Check against existing deferred imports
-                            all_deferred_imports.iter().any(|existing| {
-                                if let Stmt::Assign(existing_assign) = existing
-                                    && let [Expr::Name(existing_target)] =
-                                        existing_assign.targets.as_slice()
-                                    && existing_target.id.as_str() == target_name
-                                {
-                                    // Check if the values are the same
-                                    return expression_handlers::expr_equals(
-                                        &existing_assign.value,
-                                        &assign.value,
-                                    );
-                                }
-                                false
-                            })
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
-
-                    if is_duplicate {
-                        log::debug!(
-                            "Skipping duplicate deferred import from module '{module_name}': \
-                             {stmt:?}"
-                        );
-                    } else {
-                        // Log what we're adding to deferred imports
-                        if let Stmt::Assign(assign) = &stmt
-                            && let Expr::Name(target) = &assign.targets[0]
-                        {
-                            if let Expr::Attribute(attr) = &assign.value.as_ref() {
-                                let attr_path = expression_handlers::extract_attribute_path(attr);
-                                log::debug!(
-                                    "Adding to all_deferred_imports: {} = {} (from inlined module \
-                                     '{}')",
-                                    target.id.as_str(),
-                                    attr_path,
-                                    module_name
-                                );
-                            } else if let Expr::Name(value) = &assign.value.as_ref() {
-                                log::debug!(
-                                    "Adding to all_deferred_imports: {} = {} (from inlined module \
-                                     '{}')",
-                                    target.id.as_str(),
-                                    value.id.as_str(),
-                                    module_name
-                                );
-                            }
-                        }
-                        all_deferred_imports.push(stmt);
-                    }
-                }
-            }
-        }
+        let inlining_result = super::inliner::inline_all_modules(
+            self,
+            inlinable_modules.clone(),
+            &module_exports_map,
+            &mut symbol_renames,
+            &mut global_symbols,
+            python_version,
+        )?;
+        let all_inlined_stmts = inlining_result.statements;
+        let mut all_deferred_imports = inlining_result.deferred_imports;
 
         // Now reorder all collected inlined statements to ensure proper declaration order
         // This handles cross-module dependencies like classes inheriting from symbols defined in
@@ -4549,7 +4183,7 @@ impl<'a> Bundler<'a> {
     }
 
     /// Check if an assignment references a module that will be created as a namespace
-    fn assignment_references_namespace_module(
+    pub(crate) fn assignment_references_namespace_module(
         &self,
         assign: &StmtAssign,
         module_name: &str,
@@ -5558,7 +5192,11 @@ impl<'a> Bundler<'a> {
     }
 
     /// Get a unique name for a symbol, using the module suffix pattern
-    fn get_unique_name_with_module_suffix(&self, base_name: &str, module_name: &str) -> String {
+    pub(crate) fn get_unique_name_with_module_suffix(
+        &self,
+        base_name: &str,
+        module_name: &str,
+    ) -> String {
         let module_suffix = sanitize_module_name_for_identifier(module_name);
         format!("{base_name}_{module_suffix}")
     }
@@ -5622,7 +5260,11 @@ impl<'a> Bundler<'a> {
     }
 
     /// Rewrite hard dependencies in a module's AST
-    fn rewrite_hard_dependencies_in_module(&self, ast: &mut ModModule, module_name: &str) {
+    pub(crate) fn rewrite_hard_dependencies_in_module(
+        &self,
+        ast: &mut ModModule,
+        module_name: &str,
+    ) {
         log::debug!("Rewriting hard dependencies in module {module_name}");
 
         for stmt in &mut ast.body {
@@ -5721,7 +5363,7 @@ impl<'a> Bundler<'a> {
     }
 
     /// Reorder statements in a module based on symbol dependencies for circular modules
-    fn reorder_statements_for_circular_module(
+    pub(crate) fn reorder_statements_for_circular_module(
         &self,
         module_name: &str,
         statements: Vec<Stmt>,
@@ -6011,7 +5653,10 @@ impl<'a> Bundler<'a> {
     }
 
     /// Reorder statements to ensure proper declaration order
-    fn reorder_statements_for_proper_declaration_order(&self, statements: Vec<Stmt>) -> Vec<Stmt> {
+    pub(crate) fn reorder_statements_for_proper_declaration_order(
+        &self,
+        statements: Vec<Stmt>,
+    ) -> Vec<Stmt> {
         log::debug!("Reordering {} statements", statements.len());
         let mut imports = Vec::new();
         let mut self_assignments = Vec::new();
@@ -6206,7 +5851,7 @@ impl<'a> Bundler<'a> {
     }
 
     /// Resolve import aliases in a statement
-    fn resolve_import_aliases_in_stmt(
+    pub(crate) fn resolve_import_aliases_in_stmt(
         stmt: &mut Stmt,
         import_aliases: &FxIndexMap<String, String>,
     ) {
@@ -6231,364 +5876,6 @@ impl<'a> Bundler<'a> {
             }
             _ => {}
         }
-    }
-
-    /// Inline a class definition
-    fn inline_class(
-        &mut self,
-        class_def: &StmtClassDef,
-        module_name: &str,
-        module_renames: &mut FxIndexMap<String, String>,
-        ctx: &mut InlineContext,
-    ) {
-        let class_name = class_def.name.to_string();
-        if !self.should_inline_symbol(&class_name, module_name, ctx.module_exports_map) {
-            return;
-        }
-
-        // Check if this symbol was renamed by semantic analysis
-        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
-            if let Some(new_name) = module_rename_map.get(&class_name) {
-                // Only use semantic rename if it's actually different
-                if new_name == &class_name {
-                    // Semantic rename is same as original, check if there's a conflict
-                    if ctx.global_symbols.contains(&class_name) {
-                        // There's a conflict, apply module suffix pattern
-                        let base_name =
-                            self.get_unique_name_with_module_suffix(&class_name, module_name);
-                        generate_unique_name(&base_name, ctx.global_symbols)
-                    } else {
-                        // No conflict, use original name
-                        class_name.clone()
-                    }
-                } else {
-                    log::debug!(
-                        "Using semantic rename for class '{class_name}' to '{new_name}' in module \
-                         '{module_name}'"
-                    );
-                    new_name.clone()
-                }
-            } else {
-                // No semantic rename, check if there's a conflict
-                if ctx.global_symbols.contains(&class_name) {
-                    // There's a conflict, apply module suffix pattern
-                    let base_name =
-                        self.get_unique_name_with_module_suffix(&class_name, module_name);
-                    generate_unique_name(&base_name, ctx.global_symbols)
-                } else {
-                    // No conflict, use original name
-                    class_name.clone()
-                }
-            }
-        } else {
-            // No semantic rename, check if there's a conflict
-            if ctx.global_symbols.contains(&class_name) {
-                // There's a conflict, apply module suffix pattern
-                let base_name = self.get_unique_name_with_module_suffix(&class_name, module_name);
-                generate_unique_name(&base_name, ctx.global_symbols)
-            } else {
-                // No conflict, use original name
-                class_name.clone()
-            }
-        };
-
-        // Always track the symbol mapping, even if not renamed
-        module_renames.insert(class_name.clone(), renamed_name.clone());
-        ctx.global_symbols.insert(renamed_name.clone());
-
-        // Clone and rename the class
-        let mut class_def_clone = class_def.clone();
-        class_def_clone.name = Identifier::new(renamed_name.clone(), TextRange::default());
-
-        // Apply renames to base classes
-        // CRITICAL: For cross-module inheritance, we need to apply renames from the
-        // source module of each base class, not just from the current module.
-        if let Some(ref mut arguments) = class_def_clone.arguments {
-            for arg in &mut arguments.args {
-                // Try to determine the source module for base class names
-                if let Expr::Name(name_expr) = arg {
-                    let base_class_name = name_expr.id.as_str();
-
-                    // Check if this base class was imported from another module
-                    if let Some(source_module) = ctx.import_sources.get(base_class_name) {
-                        // This base class was imported from another module
-                        // Use that module's renames instead of the current module's
-                        if let Some(source_renames) = ctx.module_renames.get(source_module)
-                            && let Some(renamed) = source_renames.get(base_class_name)
-                        {
-                            log::debug!(
-                                "Applying cross-module rename for base class '{base_class_name}' \
-                                 from module '{source_module}': '{base_class_name}' -> '{renamed}'"
-                            );
-                            name_expr.id = renamed.clone().into();
-                            continue;
-                        }
-                    }
-
-                    // Not imported or no rename found in source module, apply local renames
-                    if let Some(renamed) = module_renames.get(base_class_name) {
-                        name_expr.id = renamed.clone().into();
-                    }
-                } else {
-                    // Complex base class expression, use standard rewriting
-                    expression_handlers::rewrite_aliases_in_expr(arg, module_renames);
-                }
-            }
-        }
-
-        // Apply renames and resolve import aliases in class body
-        for body_stmt in &mut class_def_clone.body {
-            Self::resolve_import_aliases_in_stmt(body_stmt, &ctx.import_aliases);
-            expression_handlers::rewrite_aliases_in_stmt(body_stmt, module_renames);
-            // Also apply semantic renames from context
-            if let Some(semantic_renames) = ctx.module_renames.get(module_name) {
-                expression_handlers::rewrite_aliases_in_stmt(body_stmt, semantic_renames);
-            }
-        }
-
-        ctx.inlined_stmts.push(Stmt::ClassDef(class_def_clone));
-
-        // Set the __module__ attribute to preserve the original module name
-        ctx.inlined_stmts.push(statements::set_string_attribute(
-            &renamed_name,
-            "__module__",
-            module_name,
-        ));
-
-        // If the class was renamed, also set __name__ to preserve the original class name
-        if renamed_name != class_name {
-            ctx.inlined_stmts.push(statements::set_string_attribute(
-                &renamed_name,
-                "__name__",
-                &class_name,
-            ));
-
-            // Set __qualname__ to match __name__ for proper repr()
-            ctx.inlined_stmts.push(statements::set_string_attribute(
-                &renamed_name,
-                "__qualname__",
-                &class_name,
-            ));
-        }
-    }
-
-    /// Inline an assignment statement
-    fn inline_assignment(
-        &mut self,
-        assign: &StmtAssign,
-        module_name: &str,
-        module_renames: &mut FxIndexMap<String, String>,
-        ctx: &mut InlineContext,
-    ) {
-        let Some(name) = self.extract_simple_assign_target(assign) else {
-            return;
-        };
-
-        // Special handling for circular modules: include private module-level variables
-        // that may be used by public functions
-        let is_circular_module = self.circular_modules.contains(module_name);
-        let is_single_underscore_private = name.starts_with('_') && !name.starts_with("__");
-
-        // For circular modules, we need special handling of private variables
-        if is_circular_module && is_single_underscore_private {
-            // For circular modules, we always include single-underscore private module-level
-            // variables because they might be used by functions that are part of the
-            // circular dependency
-            log::debug!("Including private variable '{name}' from circular module '{module_name}'");
-        } else if !self.should_inline_symbol(&name, module_name, ctx.module_exports_map) {
-            // For all other cases, use the standard inlining check
-            return;
-        }
-
-        // Clone the assignment first
-        let mut assign_clone = assign.clone();
-
-        // Check if this is a self-referential assignment
-        let is_self_referential = self.is_self_referential_assignment(assign, ctx.python_version);
-
-        // Skip self-referential assignments entirely - they're meaningless
-        if is_self_referential {
-            log::debug!("Skipping self-referential assignment '{name}' in module '{module_name}'");
-            // Still need to track the rename for the symbol so namespace creation works
-            // But we should check if there's already a rename for this symbol
-            // (e.g., from a function or class definition)
-            if !module_renames.contains_key(&name) {
-                // Only create a rename if we haven't seen this symbol yet
-                let renamed_name = if let Some(module_rename_map) =
-                    ctx.module_renames.get(module_name)
-                {
-                    if let Some(new_name) = module_rename_map.get(&name) {
-                        new_name.clone()
-                    } else if ctx.global_symbols.contains(&name) {
-                        let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
-                        generate_unique_name(&base_name, ctx.global_symbols)
-                    } else {
-                        name.clone()
-                    }
-                } else if ctx.global_symbols.contains(&name) {
-                    let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
-                    generate_unique_name(&base_name, ctx.global_symbols)
-                } else {
-                    name.clone()
-                };
-                module_renames.insert(name.clone(), renamed_name.clone());
-                ctx.global_symbols.insert(renamed_name);
-            }
-            return;
-        }
-
-        // Apply existing renames to the RHS value BEFORE creating new rename for LHS
-        expression_handlers::resolve_import_aliases_in_expr(
-            &mut assign_clone.value,
-            &ctx.import_aliases,
-        );
-        expression_handlers::rewrite_aliases_in_expr(&mut assign_clone.value, module_renames);
-
-        // Now create a new rename for the LHS
-        // Check if this symbol was renamed by semantic analysis
-        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
-            if let Some(new_name) = module_rename_map.get(&name) {
-                // Only use semantic rename if it's actually different
-                if new_name == &name {
-                    // Semantic rename is same as original, check if there's a conflict
-                    if ctx.global_symbols.contains(&name) {
-                        // There's a conflict, apply module suffix pattern
-                        let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
-                        generate_unique_name(&base_name, ctx.global_symbols)
-                    } else {
-                        // No conflict, use original name
-                        name.clone()
-                    }
-                } else {
-                    log::debug!(
-                        "Using semantic rename for variable '{name}' to '{new_name}' in module \
-                         '{module_name}'"
-                    );
-                    new_name.clone()
-                }
-            } else {
-                // No semantic rename, check if there's a conflict
-                if ctx.global_symbols.contains(&name) {
-                    // There's a conflict, apply module suffix pattern
-                    let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
-                    generate_unique_name(&base_name, ctx.global_symbols)
-                } else {
-                    // No conflict, use original name
-                    name.clone()
-                }
-            }
-        } else {
-            // No semantic rename, check if there's a conflict
-            if ctx.global_symbols.contains(&name) {
-                // There's a conflict, apply module suffix pattern
-                let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
-                generate_unique_name(&base_name, ctx.global_symbols)
-            } else {
-                // No conflict, use original name
-                name.clone()
-            }
-        };
-
-        // Always track the symbol mapping, even if not renamed
-        module_renames.insert(name.clone(), renamed_name.clone());
-        ctx.global_symbols.insert(renamed_name.clone());
-
-        // Apply the rename to the LHS
-        if let Expr::Name(name_expr) = &mut assign_clone.targets[0] {
-            name_expr.id = renamed_name.clone().into();
-        }
-
-        // Check if this assignment references a module that will be created as a namespace
-        // If it does, we need to defer it until after namespace creation
-        if self.assignment_references_namespace_module(&assign_clone, module_name, ctx) {
-            log::debug!(
-                "Deferring assignment '{name}' in module '{module_name}' as it references a \
-                 namespace module"
-            );
-            ctx.deferred_imports.push(Stmt::Assign(assign_clone));
-        } else {
-            ctx.inlined_stmts.push(Stmt::Assign(assign_clone));
-        }
-    }
-
-    /// Inline an annotated assignment statement
-    fn inline_ann_assignment(
-        &mut self,
-        ann_assign: &ruff_python_ast::StmtAnnAssign,
-        module_name: &str,
-        module_renames: &mut FxIndexMap<String, String>,
-        ctx: &mut InlineContext,
-    ) {
-        let Expr::Name(name) = ann_assign.target.as_ref() else {
-            return;
-        };
-
-        let var_name = name.id.to_string();
-        if !self.should_inline_symbol(&var_name, module_name, ctx.module_exports_map) {
-            return;
-        }
-
-        // Check if this symbol was renamed by semantic analysis
-        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
-            if let Some(new_name) = module_rename_map.get(&var_name) {
-                // Only use semantic rename if it's actually different
-                if new_name == &var_name {
-                    // Semantic rename is same as original, check if there's a conflict
-                    if ctx.global_symbols.contains(&var_name) {
-                        // There's a conflict, apply module suffix pattern
-                        let base_name =
-                            self.get_unique_name_with_module_suffix(&var_name, module_name);
-                        generate_unique_name(&base_name, ctx.global_symbols)
-                    } else {
-                        // No conflict, use original name
-                        var_name.clone()
-                    }
-                } else {
-                    log::debug!(
-                        "Using semantic rename for annotated variable '{var_name}' to \
-                         '{new_name}' in module '{module_name}'"
-                    );
-                    new_name.clone()
-                }
-            } else {
-                // No semantic rename, check if there's a conflict
-                if ctx.global_symbols.contains(&var_name) {
-                    // There's a conflict, apply module suffix pattern
-                    let base_name = self.get_unique_name_with_module_suffix(&var_name, module_name);
-                    generate_unique_name(&base_name, ctx.global_symbols)
-                } else {
-                    // No conflict, use original name
-                    var_name.clone()
-                }
-            }
-        } else {
-            // No semantic rename, check if there's a conflict
-            if ctx.global_symbols.contains(&var_name) {
-                // There's a conflict, apply module suffix pattern
-                let base_name = self.get_unique_name_with_module_suffix(&var_name, module_name);
-                generate_unique_name(&base_name, ctx.global_symbols)
-            } else {
-                // No conflict, use original name
-                var_name.clone()
-            }
-        };
-
-        // Always track the symbol mapping, even if not renamed
-        module_renames.insert(var_name.clone(), renamed_name.clone());
-        if renamed_name != var_name {
-            log::debug!(
-                "Renaming annotated variable '{var_name}' to '{renamed_name}' in module \
-                 '{module_name}'"
-            );
-        }
-        ctx.global_symbols.insert(renamed_name.clone());
-
-        // Clone and rename the annotated assignment
-        let mut ann_assign_clone = ann_assign.clone();
-        if let Expr::Name(name_expr) = ann_assign_clone.target.as_mut() {
-            name_expr.id = renamed_name.into();
-        }
-        ctx.inlined_stmts.push(Stmt::AnnAssign(ann_assign_clone));
     }
 }
 

--- a/crates/cribo/src/code_generator/inliner.rs
+++ b/crates/cribo/src/code_generator/inliner.rs
@@ -626,7 +626,7 @@ impl Bundler<'_> {
 /// Inline all modules into the bundle
 pub fn inline_all_modules(
     bundler: &mut Bundler,
-    inlinable_modules: Vec<(String, ModModule, std::path::PathBuf, String)>,
+    inlinable_modules: &[(String, ModModule, std::path::PathBuf, String)],
     module_exports_map: &FxIndexMap<String, Option<Vec<String>>>,
     symbol_renames: &mut FxIndexMap<String, FxIndexMap<String, String>>,
     global_symbols: &mut FxIndexSet<String>,
@@ -635,7 +635,7 @@ pub fn inline_all_modules(
     let mut all_deferred_imports = Vec::new();
     let mut all_inlined_stmts = Vec::new();
 
-    for (module_name, ast, module_path, _content_hash) in &inlinable_modules {
+    for (module_name, ast, module_path, _content_hash) in inlinable_modules {
         debug!("Inlining module '{module_name}'");
 
         let mut inlined_stmts = Vec::new();

--- a/crates/cribo/src/code_generator/inliner.rs
+++ b/crates/cribo/src/code_generator/inliner.rs
@@ -721,8 +721,12 @@ pub fn inline_all_modules(
                             if let Stmt::Assign(existing_assign) = existing
                                 && let [Expr::Name(existing_target)] =
                                     existing_assign.targets.as_slice()
+                                && existing_target.id.as_str() == target_name
                             {
-                                existing_target.id.as_str() == target_name
+                                expression_handlers::expr_equals(
+                                    &assign.value,
+                                    &existing_assign.value,
+                                )
                             } else {
                                 false
                             }

--- a/crates/cribo/src/code_generator/inliner.rs
+++ b/crates/cribo/src/code_generator/inliner.rs
@@ -1,0 +1,748 @@
+//! Module inlining functionality for the bundler
+//!
+//! This module handles the inlining of Python modules into the final bundle,
+//! including class, assignment, and annotation inlining.
+
+use std::path::Path;
+
+use anyhow::Result;
+use log::debug;
+use ruff_python_ast::{Expr, Identifier, ModModule, Stmt, StmtAssign, StmtClassDef};
+use ruff_text_size::TextRange;
+
+use super::{
+    bundler::Bundler,
+    context::InlineContext,
+    expression_handlers, import_deduplicator,
+    import_transformer::{RecursiveImportTransformer, RecursiveImportTransformerParams},
+    module_registry::generate_unique_name,
+};
+use crate::{
+    ast_builder::statements,
+    types::{FxIndexMap, FxIndexSet},
+};
+
+/// Result of the inlining process
+pub struct InliningResult {
+    /// The statements generated from inlining
+    pub statements: Vec<Stmt>,
+    /// Import statements that need to be deferred
+    pub deferred_imports: Vec<Stmt>,
+}
+
+impl Bundler<'_> {
+    /// Inline a module
+    pub fn inline_module(
+        &mut self,
+        module_name: &str,
+        mut ast: ModModule,
+        module_path: &Path,
+        ctx: &mut InlineContext,
+    ) -> Result<Vec<Stmt>> {
+        let mut module_renames = FxIndexMap::default();
+
+        // Apply hard dependency rewriting BEFORE import transformation
+        if !self.hard_dependencies.is_empty() && self.circular_modules.contains(module_name) {
+            self.rewrite_hard_dependencies_in_module(&mut ast, module_name);
+        }
+
+        // Then apply recursive import transformation to the module
+        let mut transformer = RecursiveImportTransformer::new(RecursiveImportTransformerParams {
+            bundler: self,
+            module_name,
+            module_path: Some(module_path),
+            symbol_renames: ctx.module_renames,
+            deferred_imports: ctx.deferred_imports,
+            is_entry_module: false, // This is not the entry module
+            is_wrapper_init: false, // Not a wrapper init
+            global_deferred_imports: Some(&self.global_deferred_imports), // Pass global registry
+        });
+        transformer.transform_module(&mut ast);
+
+        // Copy import aliases from the transformer to the inline context
+        ctx.import_aliases = transformer.import_aliases;
+
+        // Reorder statements to ensure proper declaration order
+        let statements = if self.circular_modules.contains(module_name) {
+            self.reorder_statements_for_circular_module(module_name, ast.body, ctx.python_version)
+        } else {
+            // Even for non-circular modules, ensure module-level variables are declared
+            // before functions that might use them
+            self.reorder_statements_for_proper_declaration_order(ast.body)
+        };
+
+        // Build a map of imported symbols to their source modules
+        ctx.import_sources = self.build_import_source_map(&statements, module_name);
+
+        // Process each statement in the module
+        for stmt in statements {
+            match &stmt {
+                Stmt::Import(import_stmt) => {
+                    // Imports have already been transformed by RecursiveImportTransformer
+                    // Include them in the inlined output
+                    if !import_deduplicator::is_hoisted_import(self, &stmt) {
+                        log::debug!(
+                            "Including non-hoisted import in inlined module '{}': {:?}",
+                            module_name,
+                            import_stmt
+                                .names
+                                .iter()
+                                .map(|a| (
+                                    a.name.as_str(),
+                                    a.asname.as_ref().map(ruff_python_ast::Identifier::as_str)
+                                ))
+                                .collect::<Vec<_>>()
+                        );
+                        ctx.inlined_stmts.push(stmt.clone());
+                    }
+                }
+                Stmt::ImportFrom(_) => {
+                    // Imports have already been transformed by RecursiveImportTransformer
+                    // Include them in the inlined output
+                    if !import_deduplicator::is_hoisted_import(self, &stmt) {
+                        ctx.inlined_stmts.push(stmt.clone());
+                    }
+                }
+                Stmt::FunctionDef(func_def) => {
+                    let func_name = func_def.name.to_string();
+                    if !self.should_inline_symbol(&func_name, module_name, ctx.module_exports_map) {
+                        continue;
+                    }
+
+                    // Check if this symbol was renamed by semantic analysis
+                    let renamed_name = if let Some(module_rename_map) =
+                        ctx.module_renames.get(module_name)
+                    {
+                        if let Some(new_name) = module_rename_map.get(&func_name) {
+                            // Only use semantic rename if it's actually different
+                            if new_name == &func_name {
+                                // Semantic rename is same as original, check if there's a conflict
+                                if ctx.global_symbols.contains(&func_name) {
+                                    // There's a conflict, apply module suffix pattern
+                                    let base_name = self.get_unique_name_with_module_suffix(
+                                        &func_name,
+                                        module_name,
+                                    );
+                                    generate_unique_name(&base_name, ctx.global_symbols)
+                                } else {
+                                    // No conflict, use original name
+                                    func_name.clone()
+                                }
+                            } else {
+                                log::debug!(
+                                    "Using semantic rename for '{func_name}' to '{new_name}' in \
+                                     module '{module_name}'"
+                                );
+                                new_name.clone()
+                            }
+                        } else {
+                            // No semantic rename, check if there's a conflict
+                            if ctx.global_symbols.contains(&func_name) {
+                                // There's a conflict, apply module suffix pattern
+                                let base_name = self
+                                    .get_unique_name_with_module_suffix(&func_name, module_name);
+                                generate_unique_name(&base_name, ctx.global_symbols)
+                            } else {
+                                // No conflict, use original name
+                                func_name.clone()
+                            }
+                        }
+                    } else {
+                        // No semantic rename, check if there's a conflict
+                        if ctx.global_symbols.contains(&func_name) {
+                            // There's a conflict, apply module suffix pattern
+                            let base_name =
+                                self.get_unique_name_with_module_suffix(&func_name, module_name);
+                            generate_unique_name(&base_name, ctx.global_symbols)
+                        } else {
+                            // No conflict, use original name
+                            func_name.clone()
+                        }
+                    };
+
+                    // Always track the symbol mapping, even if not renamed
+                    module_renames.insert(func_name.clone(), renamed_name.clone());
+                    ctx.global_symbols.insert(renamed_name.clone());
+
+                    // Clone and rename the function
+                    let mut func_def_clone = func_def.clone();
+                    func_def_clone.name = Identifier::new(renamed_name, TextRange::default());
+
+                    // Apply renames to function annotations (parameters and return type)
+                    if let Some(ref mut returns) = func_def_clone.returns {
+                        expression_handlers::resolve_import_aliases_in_expr(
+                            returns,
+                            &ctx.import_aliases,
+                        );
+                        expression_handlers::rewrite_aliases_in_expr(returns, &module_renames);
+                    }
+
+                    // Apply renames to parameter annotations
+                    for param in &mut func_def_clone.parameters.args {
+                        if let Some(ref mut annotation) = param.parameter.annotation {
+                            expression_handlers::resolve_import_aliases_in_expr(
+                                annotation,
+                                &ctx.import_aliases,
+                            );
+                            expression_handlers::rewrite_aliases_in_expr(
+                                annotation,
+                                &module_renames,
+                            );
+                        }
+                    }
+
+                    // First resolve import aliases in function body
+                    for body_stmt in &mut func_def_clone.body {
+                        Self::resolve_import_aliases_in_stmt(body_stmt, &ctx.import_aliases);
+                    }
+
+                    // Create a temporary statement to rewrite the entire function properly
+                    let mut temp_stmt = Stmt::FunctionDef(func_def_clone);
+
+                    // Apply renames to the entire function (this will handle global statements
+                    // correctly)
+                    expression_handlers::rewrite_aliases_in_stmt(&mut temp_stmt, &module_renames);
+
+                    // Also apply semantic renames from context
+                    if let Some(semantic_renames) = ctx.module_renames.get(module_name) {
+                        expression_handlers::rewrite_aliases_in_stmt(
+                            &mut temp_stmt,
+                            semantic_renames,
+                        );
+                    }
+
+                    ctx.inlined_stmts.push(temp_stmt);
+                }
+                Stmt::ClassDef(class_def) => {
+                    self.inline_class(class_def, module_name, &mut module_renames, ctx);
+                }
+                Stmt::Assign(assign) => {
+                    self.inline_assignment(assign, module_name, &mut module_renames, ctx);
+                }
+                Stmt::AnnAssign(ann_assign) => {
+                    self.inline_ann_assignment(ann_assign, module_name, &mut module_renames, ctx);
+                }
+                // TypeAlias statements are safe metadata definitions
+                Stmt::TypeAlias(_) => {
+                    // Type aliases don't need renaming in Python, they're just metadata
+                    ctx.inlined_stmts.push(stmt);
+                }
+                // Pass statements are no-ops and safe
+                Stmt::Pass(_) => {
+                    // Pass statements can be included as-is
+                    ctx.inlined_stmts.push(stmt);
+                }
+                // Expression statements that are string literals are docstrings
+                Stmt::Expr(expr_stmt) => {
+                    if matches!(expr_stmt.value.as_ref(), Expr::StringLiteral(_)) {
+                        // This is a docstring - safe to include
+                        ctx.inlined_stmts.push(stmt);
+                    } else {
+                        // Other expression statements shouldn't exist in side-effect-free modules
+                        log::warn!(
+                            "Unexpected expression statement in side-effect-free module \
+                             '{module_name}': {stmt:?}"
+                        );
+                    }
+                }
+                _ => {
+                    // Any other statement type that we haven't explicitly handled
+                    log::warn!(
+                        "Unexpected statement type in side-effect-free module '{module_name}': \
+                         {stmt:?}"
+                    );
+                }
+            }
+        }
+
+        // Store the renames for this module
+        if !module_renames.is_empty() {
+            ctx.module_renames
+                .insert(module_name.to_string(), module_renames);
+        }
+
+        Ok(Vec::new()) // Statements are accumulated in ctx.inlined_stmts
+    }
+
+    /// Inline a class definition
+    pub(crate) fn inline_class(
+        &mut self,
+        class_def: &StmtClassDef,
+        module_name: &str,
+        module_renames: &mut FxIndexMap<String, String>,
+        ctx: &mut InlineContext,
+    ) {
+        let class_name = class_def.name.to_string();
+        if !self.should_inline_symbol(&class_name, module_name, ctx.module_exports_map) {
+            return;
+        }
+
+        // Check if this symbol was renamed by semantic analysis
+        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
+            if let Some(new_name) = module_rename_map.get(&class_name) {
+                // Only use semantic rename if it's actually different
+                if new_name == &class_name {
+                    // Semantic rename is same as original, check if there's a conflict
+                    if ctx.global_symbols.contains(&class_name) {
+                        // There's a conflict, apply module suffix pattern
+                        let base_name =
+                            self.get_unique_name_with_module_suffix(&class_name, module_name);
+                        generate_unique_name(&base_name, ctx.global_symbols)
+                    } else {
+                        // No conflict, use original name
+                        class_name.clone()
+                    }
+                } else {
+                    log::debug!(
+                        "Using semantic rename for class '{class_name}' to '{new_name}' in module \
+                         '{module_name}'"
+                    );
+                    new_name.clone()
+                }
+            } else {
+                // No semantic rename, check if there's a conflict
+                if ctx.global_symbols.contains(&class_name) {
+                    // There's a conflict, apply module suffix pattern
+                    let base_name =
+                        self.get_unique_name_with_module_suffix(&class_name, module_name);
+                    generate_unique_name(&base_name, ctx.global_symbols)
+                } else {
+                    // No conflict, use original name
+                    class_name.clone()
+                }
+            }
+        } else {
+            // No semantic rename, check if there's a conflict
+            if ctx.global_symbols.contains(&class_name) {
+                // There's a conflict, apply module suffix pattern
+                let base_name = self.get_unique_name_with_module_suffix(&class_name, module_name);
+                generate_unique_name(&base_name, ctx.global_symbols)
+            } else {
+                // No conflict, use original name
+                class_name.clone()
+            }
+        };
+
+        // Always track the symbol mapping, even if not renamed
+        module_renames.insert(class_name.clone(), renamed_name.clone());
+        ctx.global_symbols.insert(renamed_name.clone());
+
+        // Clone and rename the class
+        let mut class_def_clone = class_def.clone();
+        class_def_clone.name = Identifier::new(renamed_name.clone(), TextRange::default());
+
+        // Apply renames to base classes
+        // CRITICAL: For cross-module inheritance, we need to apply renames from the
+        // source module of each base class, not just from the current module.
+        if let Some(ref mut arguments) = class_def_clone.arguments {
+            for arg in &mut arguments.args {
+                // Try to determine the source module for base class names
+                if let Expr::Name(name_expr) = arg {
+                    let base_class_name = name_expr.id.as_str();
+
+                    // Check if this base class was imported from another module
+                    if let Some(source_module) = ctx.import_sources.get(base_class_name) {
+                        // This base class was imported from another module
+                        // Use that module's renames instead of the current module's
+                        if let Some(source_renames) = ctx.module_renames.get(source_module)
+                            && let Some(renamed) = source_renames.get(base_class_name)
+                        {
+                            log::debug!(
+                                "Applying cross-module rename for base class '{base_class_name}' \
+                                 from module '{source_module}': '{base_class_name}' -> '{renamed}'"
+                            );
+                            name_expr.id = renamed.clone().into();
+                            continue;
+                        }
+                    }
+
+                    // Not imported or no rename found in source module, apply local renames
+                    if let Some(renamed) = module_renames.get(base_class_name) {
+                        name_expr.id = renamed.clone().into();
+                    }
+                } else {
+                    // Complex base class expression, use standard rewriting
+                    expression_handlers::rewrite_aliases_in_expr(arg, module_renames);
+                }
+            }
+        }
+
+        // Apply renames and resolve import aliases in class body
+        for body_stmt in &mut class_def_clone.body {
+            Self::resolve_import_aliases_in_stmt(body_stmt, &ctx.import_aliases);
+            expression_handlers::rewrite_aliases_in_stmt(body_stmt, module_renames);
+            // Also apply semantic renames from context
+            if let Some(semantic_renames) = ctx.module_renames.get(module_name) {
+                expression_handlers::rewrite_aliases_in_stmt(body_stmt, semantic_renames);
+            }
+        }
+
+        ctx.inlined_stmts.push(Stmt::ClassDef(class_def_clone));
+
+        // Set the __module__ attribute to preserve the original module name
+        ctx.inlined_stmts.push(statements::set_string_attribute(
+            &renamed_name,
+            "__module__",
+            module_name,
+        ));
+
+        // If the class was renamed, also set __name__ to preserve the original class name
+        if renamed_name != class_name {
+            ctx.inlined_stmts.push(statements::set_string_attribute(
+                &renamed_name,
+                "__name__",
+                &class_name,
+            ));
+
+            // Set __qualname__ to match __name__ for proper repr()
+            ctx.inlined_stmts.push(statements::set_string_attribute(
+                &renamed_name,
+                "__qualname__",
+                &class_name,
+            ));
+        }
+    }
+
+    /// Inline an assignment statement
+    pub(crate) fn inline_assignment(
+        &mut self,
+        assign: &StmtAssign,
+        module_name: &str,
+        module_renames: &mut FxIndexMap<String, String>,
+        ctx: &mut InlineContext,
+    ) {
+        let Some(name) = self.extract_simple_assign_target(assign) else {
+            return;
+        };
+
+        // Special handling for circular modules: include private module-level variables
+        // that may be used by public functions
+        let is_circular_module = self.circular_modules.contains(module_name);
+        let is_single_underscore_private = name.starts_with('_') && !name.starts_with("__");
+
+        // For circular modules, we need special handling of private variables
+        if is_circular_module && is_single_underscore_private {
+            // For circular modules, we always include single-underscore private module-level
+            // variables because they might be used by functions that are part of the
+            // circular dependency
+            log::debug!("Including private variable '{name}' from circular module '{module_name}'");
+        } else if !self.should_inline_symbol(&name, module_name, ctx.module_exports_map) {
+            // For all other cases, use the standard inlining check
+            return;
+        }
+
+        // Clone the assignment first
+        let mut assign_clone = assign.clone();
+
+        // Check if this is a self-referential assignment
+        let is_self_referential = self.is_self_referential_assignment(assign, ctx.python_version);
+
+        // Skip self-referential assignments entirely - they're meaningless
+        if is_self_referential {
+            log::debug!("Skipping self-referential assignment '{name}' in module '{module_name}'");
+            // Still need to track the rename for the symbol so namespace creation works
+            // But we should check if there's already a rename for this symbol
+            // (e.g., from a function or class definition)
+            if !module_renames.contains_key(&name) {
+                // Only create a rename if we haven't seen this symbol yet
+                let renamed_name = if let Some(module_rename_map) =
+                    ctx.module_renames.get(module_name)
+                {
+                    if let Some(new_name) = module_rename_map.get(&name) {
+                        new_name.clone()
+                    } else if ctx.global_symbols.contains(&name) {
+                        let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
+                        generate_unique_name(&base_name, ctx.global_symbols)
+                    } else {
+                        name.clone()
+                    }
+                } else if ctx.global_symbols.contains(&name) {
+                    let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
+                    generate_unique_name(&base_name, ctx.global_symbols)
+                } else {
+                    name.clone()
+                };
+                module_renames.insert(name.clone(), renamed_name.clone());
+                ctx.global_symbols.insert(renamed_name);
+            }
+            return;
+        }
+
+        // Apply existing renames to the RHS value BEFORE creating new rename for LHS
+        expression_handlers::resolve_import_aliases_in_expr(
+            &mut assign_clone.value,
+            &ctx.import_aliases,
+        );
+        expression_handlers::rewrite_aliases_in_expr(&mut assign_clone.value, module_renames);
+
+        // Now create a new rename for the LHS
+        // Check if this symbol was renamed by semantic analysis
+        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
+            if let Some(new_name) = module_rename_map.get(&name) {
+                // Only use semantic rename if it's actually different
+                if new_name == &name {
+                    // Semantic rename is same as original, check if there's a conflict
+                    if ctx.global_symbols.contains(&name) {
+                        // There's a conflict, apply module suffix pattern
+                        let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
+                        generate_unique_name(&base_name, ctx.global_symbols)
+                    } else {
+                        // No conflict, use original name
+                        name.clone()
+                    }
+                } else {
+                    log::debug!(
+                        "Using semantic rename for variable '{name}' to '{new_name}' in module \
+                         '{module_name}'"
+                    );
+                    new_name.clone()
+                }
+            } else {
+                // No semantic rename, check if there's a conflict
+                if ctx.global_symbols.contains(&name) {
+                    // There's a conflict, apply module suffix pattern
+                    let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
+                    generate_unique_name(&base_name, ctx.global_symbols)
+                } else {
+                    // No conflict, use original name
+                    name.clone()
+                }
+            }
+        } else {
+            // No semantic rename, check if there's a conflict
+            if ctx.global_symbols.contains(&name) {
+                // There's a conflict, apply module suffix pattern
+                let base_name = self.get_unique_name_with_module_suffix(&name, module_name);
+                generate_unique_name(&base_name, ctx.global_symbols)
+            } else {
+                // No conflict, use original name
+                name.clone()
+            }
+        };
+
+        // Always track the symbol mapping, even if not renamed
+        module_renames.insert(name.clone(), renamed_name.clone());
+        ctx.global_symbols.insert(renamed_name.clone());
+
+        // Apply the rename to the LHS
+        if let Expr::Name(name_expr) = &mut assign_clone.targets[0] {
+            name_expr.id = renamed_name.clone().into();
+        }
+
+        // Check if this assignment references a module that will be created as a namespace
+        // If it does, we need to defer it until after namespace creation
+        if self.assignment_references_namespace_module(&assign_clone, module_name, ctx) {
+            log::debug!(
+                "Deferring assignment '{name}' in module '{module_name}' as it references a \
+                 namespace module"
+            );
+            ctx.deferred_imports.push(Stmt::Assign(assign_clone));
+        } else {
+            ctx.inlined_stmts.push(Stmt::Assign(assign_clone));
+        }
+    }
+
+    /// Inline an annotated assignment statement
+    pub(crate) fn inline_ann_assignment(
+        &mut self,
+        ann_assign: &ruff_python_ast::StmtAnnAssign,
+        module_name: &str,
+        module_renames: &mut FxIndexMap<String, String>,
+        ctx: &mut InlineContext,
+    ) {
+        let Expr::Name(name) = ann_assign.target.as_ref() else {
+            return;
+        };
+
+        let var_name = name.id.to_string();
+        if !self.should_inline_symbol(&var_name, module_name, ctx.module_exports_map) {
+            return;
+        }
+
+        // Check if this symbol was renamed by semantic analysis
+        let renamed_name = if let Some(module_rename_map) = ctx.module_renames.get(module_name) {
+            if let Some(new_name) = module_rename_map.get(&var_name) {
+                // Only use semantic rename if it's actually different
+                if new_name == &var_name {
+                    // Semantic rename is same as original, check if there's a conflict
+                    if ctx.global_symbols.contains(&var_name) {
+                        // There's a conflict, apply module suffix pattern
+                        let base_name =
+                            self.get_unique_name_with_module_suffix(&var_name, module_name);
+                        generate_unique_name(&base_name, ctx.global_symbols)
+                    } else {
+                        // No conflict, use original name
+                        var_name.clone()
+                    }
+                } else {
+                    log::debug!(
+                        "Using semantic rename for annotated variable '{var_name}' to \
+                         '{new_name}' in module '{module_name}'"
+                    );
+                    new_name.clone()
+                }
+            } else {
+                // No semantic rename, check if there's a conflict
+                if ctx.global_symbols.contains(&var_name) {
+                    // There's a conflict, apply module suffix pattern
+                    let base_name = self.get_unique_name_with_module_suffix(&var_name, module_name);
+                    generate_unique_name(&base_name, ctx.global_symbols)
+                } else {
+                    // No conflict, use original name
+                    var_name.clone()
+                }
+            }
+        } else {
+            // No semantic rename, check if there's a conflict
+            if ctx.global_symbols.contains(&var_name) {
+                // There's a conflict, apply module suffix pattern
+                let base_name = self.get_unique_name_with_module_suffix(&var_name, module_name);
+                generate_unique_name(&base_name, ctx.global_symbols)
+            } else {
+                // No conflict, use original name
+                var_name.clone()
+            }
+        };
+
+        // Always track the symbol mapping, even if not renamed
+        module_renames.insert(var_name.clone(), renamed_name.clone());
+        if renamed_name != var_name {
+            log::debug!(
+                "Renaming annotated variable '{var_name}' to '{renamed_name}' in module \
+                 '{module_name}'"
+            );
+        }
+        ctx.global_symbols.insert(renamed_name.clone());
+
+        // Clone and rename the annotated assignment
+        let mut ann_assign_clone = ann_assign.clone();
+        if let Expr::Name(name_expr) = ann_assign_clone.target.as_mut() {
+            name_expr.id = renamed_name.into();
+        }
+        ctx.inlined_stmts.push(Stmt::AnnAssign(ann_assign_clone));
+    }
+}
+
+/// Inline all modules into the bundle
+pub fn inline_all_modules(
+    bundler: &mut Bundler,
+    inlinable_modules: Vec<(String, ModModule, std::path::PathBuf, String)>,
+    module_exports_map: &FxIndexMap<String, Option<Vec<String>>>,
+    symbol_renames: &mut FxIndexMap<String, FxIndexMap<String, String>>,
+    global_symbols: &mut FxIndexSet<String>,
+    python_version: u8,
+) -> Result<InliningResult> {
+    let mut all_deferred_imports = Vec::new();
+    let mut all_inlined_stmts = Vec::new();
+
+    for (module_name, ast, module_path, _content_hash) in &inlinable_modules {
+        debug!("Inlining module '{module_name}'");
+
+        let mut inlined_stmts = Vec::new();
+        let mut deferred_imports = Vec::new();
+        let mut inline_ctx = InlineContext {
+            module_exports_map,
+            global_symbols,
+            module_renames: symbol_renames,
+            inlined_stmts: &mut inlined_stmts,
+            import_aliases: FxIndexMap::default(),
+            deferred_imports: &mut deferred_imports,
+            import_sources: FxIndexMap::default(),
+            python_version,
+        };
+        bundler.inline_module(module_name, ast.clone(), module_path, &mut inline_ctx)?;
+        debug!(
+            "Inlined {} statements from module '{}'",
+            inlined_stmts.len(),
+            module_name
+        );
+        all_inlined_stmts.extend(inlined_stmts);
+
+        // Filter deferred imports to avoid conflicts
+        // If an inlined module imports a symbol but doesn't export it,
+        // and that symbol would conflict with other imports, skip it
+        for stmt in deferred_imports {
+            let should_include = if let Stmt::Assign(assign) = &stmt {
+                if let [Expr::Name(target)] = assign.targets.as_slice()
+                    && let Expr::Name(_value) = &*assign.value
+                {
+                    let symbol_name = target.id.as_str();
+
+                    // Check if this module exports the symbol
+                    let exports_symbol =
+                        if let Some(Some(exports)) = module_exports_map.get(module_name) {
+                            exports.contains(&symbol_name.to_string())
+                        } else {
+                            // No explicit __all__, check if it's a module-level definition
+                            // For now, assume it's not exported if there's no __all__
+                            false
+                        };
+
+                    if exports_symbol {
+                        true
+                    } else {
+                        // Check if this would conflict with existing deferred imports
+                        let has_conflict = all_deferred_imports.iter().any(|existing| {
+                            if let Stmt::Assign(existing_assign) = existing
+                                && let [Expr::Name(existing_target)] =
+                                    existing_assign.targets.as_slice()
+                            {
+                                existing_target.id.as_str() == symbol_name
+                            } else {
+                                false
+                            }
+                        });
+
+                        if has_conflict {
+                            debug!(
+                                "Skipping deferred import '{symbol_name}' from module \
+                                 '{module_name}' due to conflict"
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    }
+                } else {
+                    true
+                }
+            } else {
+                true
+            };
+
+            if should_include {
+                // Check if this deferred import already exists in all_deferred_imports
+                let is_duplicate = if let Stmt::Assign(assign) = &stmt {
+                    if let Expr::Name(target) = &assign.targets[0] {
+                        let target_name = target.id.as_str();
+
+                        // Check against existing deferred imports
+                        all_deferred_imports.iter().any(|existing| {
+                            if let Stmt::Assign(existing_assign) = existing
+                                && let [Expr::Name(existing_target)] =
+                                    existing_assign.targets.as_slice()
+                            {
+                                existing_target.id.as_str() == target_name
+                            } else {
+                                false
+                            }
+                        })
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                if !is_duplicate {
+                    all_deferred_imports.push(stmt);
+                }
+            }
+        }
+    }
+
+    Ok(InliningResult {
+        statements: all_inlined_stmts,
+        deferred_imports: all_deferred_imports,
+    })
+}

--- a/crates/cribo/src/code_generator/mod.rs
+++ b/crates/cribo/src/code_generator/mod.rs
@@ -13,6 +13,7 @@ pub mod expression_handlers;
 pub mod globals;
 pub mod import_deduplicator;
 pub mod import_transformer;
+pub mod inliner;
 pub mod module_registry;
 pub mod module_transformer;
 pub mod namespace_manager;

--- a/docs/implement-bundle-modules-split.md
+++ b/docs/implement-bundle-modules-split.md
@@ -1,0 +1,251 @@
+# Implementation Plan: Refactor bundle_modules Function
+
+## Executive Summary
+
+The `bundler.rs` file contains 7,672 lines of code, with the main `bundle_modules` function alone spanning 735 lines (lines 1546-2281). This plan describes how to refactor this monolithic structure into well-organized, maintainable modules.
+
+## Goal
+
+Break down the massive `bundler.rs` file into smaller, focused modules while maintaining all existing functionality and ensuring the code remains easy to understand and maintain.
+
+## Current Structure Analysis
+
+The `bundle_modules` function currently handles five major phases:
+
+1. **Initialization** (lines 1548-1716): Sets up tree-shaking, tracks module access, detects entry modules, collects future imports, trims imports, and indexes ASTs.
+
+2. **Module Classification** (lines 1718-1891): Detects import types, identifies circular dependencies, separates modules into inlinable vs wrapper categories, and collects exports.
+
+3. **Semantic Analysis** (lines 2025-2188): Collects symbol renames, builds circular dependency graphs, and generates pre-declarations.
+
+4. **Code Generation** (lines 2190-2259): Creates namespaces, processes wrapper modules, inlines modules, handles imports, and processes the entry module.
+
+5. **Finalization** (lines 2260-2279): Hoists imports, fixes forward references, deduplicates code, and finalizes the AST.
+
+## Refactoring Plan
+
+### New File Structure
+
+The refactoring will create ONE new file and enhance existing modules:
+
+1. **bundler.rs** (~3,000 lines)
+   - Bundler struct definition
+   - Main orchestration logic
+   - Module classification methods
+   - Semantic analysis methods
+   - Entry module processing
+   - Finalization logic
+
+2. **inliner.rs** (NEW - ~2,000 lines)
+   - All module inlining functions
+   - Class, assignment, and annotation inlining
+   - Namespace management during inlining
+
+3. **Existing modules** (enhanced with moved functions):
+   - `module_transformer.rs`: Wrapper module processing
+   - `expression_handlers.rs`: AST expression utilities
+   - `namespace_manager.rs`: Namespace creation functions
+
+### Function Migrations
+
+#### To the new `inliner.rs`:
+
+- `inline_module()` (lines 1058-1289)
+- `inline_class()` (lines 6237-6373)
+- `inline_assignment()` (lines 6376-6512)
+- `inline_ann_assignment()` (lines 6515-6592)
+- Main inlining loop logic (lines 2123-2188)
+- Related helper functions
+
+#### To `module_transformer.rs`:
+
+- `transform_module_to_cache_init_function()` (lines 989-1019)
+- `sort_wrapper_modules_by_dependencies()` (lines 950-986)
+- New function: `process_wrapper_modules()`
+
+#### To `expression_handlers.rs`:
+
+- `extract_simple_assign_target()` (lines 4509-4516)
+- `is_self_referential_assignment()` (lines 4519-4549)
+
+#### Stay in `bundler.rs`:
+
+- `find_directly_imported_modules()` (lines 4456-4463)
+- `find_namespace_imported_modules()` (lines 4466-4478)
+- `should_export_symbol()` (lines 4481-4506)
+- `is_valid_python_identifier()` (lines 704-707)
+- `module_accesses_imported_attributes()` (lines 711-831)
+
+### New Methods in bundler.rs
+
+```rust
+impl Bundler {
+    // Extract from lines 1718-1891
+    fn classify_modules(&mut self, modules: &[(String, ModModule, PathBuf, String)], 
+                       params: &BundleParams<'_>) -> Result<ClassificationResult>
+    
+    // Extract from lines 2025-2035
+    fn collect_symbol_renames(&mut self, modules: &[(String, ModModule, PathBuf, String)], 
+                             params: &BundleParams<'_>) -> Result<FxIndexMap<String, FxIndexMap<String, String>>>
+    
+    // Extract from lines 2037-2188
+    fn generate_circular_predeclarations(&mut self, /*...*/) -> Result<Vec<Stmt>>
+    
+    // Extract from lines 1548-1716
+    fn initialize_bundler(&mut self, params: &BundleParams<'_>) -> Result<()>
+    
+    // Extract import trimming and AST indexing logic
+    fn prepare_modules(&mut self, params: &BundleParams<'_>) -> Result<Vec<(String, ModModule, PathBuf, String)>>
+    
+    // Keep existing, but may need minor adjustments
+    fn process_entry_module(&mut self, /*...*/) -> Result<Vec<Stmt>>
+    
+    // Extract from lines 2260-2279
+    fn finalize_module(&mut self, body: Vec<Stmt>, params: &BundleParams<'_>) -> Result<ModModule>
+}
+```
+
+### New Public Functions
+
+In `inliner.rs`:
+
+```rust
+pub fn inline_all_modules(
+    bundler: &mut Bundler,
+    inlinable_modules: Vec<(String, ModModule, PathBuf, String)>,
+    module_exports_map: &FxIndexMap<String, Option<Vec<String>>>,
+    symbol_renames: &mut FxIndexMap<String, FxIndexMap<String, String>>,
+    params: &BundleParams<'_>,
+) -> Result<InliningResult>
+
+pub struct InliningResult {
+    pub statements: Vec<Stmt>,
+    pub deferred_imports: Vec<Stmt>,
+}
+```
+
+In `module_transformer.rs`:
+
+```rust
+pub fn process_wrapper_modules(
+    bundler: &mut Bundler,
+    wrapper_modules: &[(String, ModModule, PathBuf, String)],
+    symbol_renames: &FxIndexMap<String, FxIndexMap<String, String>>,
+    params: &BundleParams<'_>,
+) -> Result<Vec<Stmt>>
+```
+
+In `namespace_manager.rs`:
+
+```rust
+pub fn create_required_namespaces(
+    bundler: &mut Bundler,
+    modules: &[(String, ModModule, PathBuf, String)],
+    params: &BundleParams<'_>,
+) -> Result<Vec<Stmt>>
+```
+
+### Refactored bundle_modules Function
+
+```rust
+pub fn bundle_modules(&mut self, params: &BundleParams<'_>) -> Result<ModModule> {
+    // Phase 1: Initialization
+    self.initialize_bundler(params)?;
+    let mut modules = self.prepare_modules(params)?;
+
+    // Phase 2: Module Classification
+    let classification = self.classify_modules(&modules, params)?;
+
+    // Phase 3: Semantic Analysis
+    let mut symbol_renames = self.collect_symbol_renames(&modules, params)?;
+    let predeclarations = self.generate_circular_predeclarations(
+        &modules,
+        &classification.inlinable_modules,
+        &symbol_renames,
+        params,
+    )?;
+
+    // Phase 4: Code Generation
+    let mut final_body = Vec::new();
+
+    final_body.extend(predeclarations);
+    final_body.extend(namespace_manager::create_required_namespaces(
+        self, &modules, params,
+    )?);
+
+    if !classification.wrapper_modules.is_empty() {
+        let wrapper_stmts = module_transformer::process_wrapper_modules(
+            self,
+            &classification.wrapper_modules,
+            &symbol_renames,
+            params,
+        )?;
+        final_body.extend(wrapper_stmts);
+    }
+
+    let inlining_result = inliner::inline_all_modules(
+        self,
+        classification.inlinable_modules,
+        &classification.module_exports_map,
+        &mut symbol_renames,
+        params,
+    )?;
+
+    final_body.extend(inlining_result.statements);
+
+    let entry_stmts =
+        self.process_entry_module(params, &symbol_renames, inlining_result.deferred_imports)?;
+    final_body.extend(entry_stmts);
+
+    // Phase 5: Finalization
+    self.finalize_module(final_body, params)
+}
+```
+
+## Implementation Steps
+
+1. **Create `inliner.rs`**
+   - Add module declaration to `code_generator/mod.rs`
+   - Create the file with proper imports
+   - Move the four inline_* functions
+   - Extract the main inlining loop into `inline_all_modules`
+
+2. **Move utility functions**
+   - Move expression-related functions to `expression_handlers.rs`
+   - Move module transformation functions to `module_transformer.rs`
+
+3. **Extract bundler methods**
+   - Create `classify_modules` method
+   - Create `collect_symbol_renames` method
+   - Create `generate_circular_predeclarations` method
+   - Create `initialize_bundler` and `prepare_modules` methods
+   - Create `finalize_module` method
+
+4. **Enhance existing modules**
+   - Add `process_wrapper_modules` to `module_transformer.rs`
+   - Add `create_required_namespaces` to `namespace_manager.rs`
+
+5. **Update bundle_modules**
+   - Replace inline code with calls to new methods and functions
+   - Ensure all imports are correct
+
+6. **Test thoroughly**
+   - Run `cargo test --workspace`
+   - Run `cargo clippy --workspace --all-targets`
+   - Verify snapshot tests still pass
+
+## Success Criteria
+
+- All existing tests pass
+- No clippy warnings
+- `bundler.rs` reduced from 7,672 to ~3,000 lines
+- Code organization is clearer and more maintainable
+- No change in bundling behavior or output
+
+## Notes for Implementation
+
+- When moving functions, update all imports and visibility modifiers
+- Maintain the exact same logic - this is a refactoring, not a rewrite
+- If a function needs access to Bundler fields, pass `&mut Bundler` as the first parameter
+- Keep related functions together in the same module
+- Add appropriate documentation comments to new public functions


### PR DESCRIPTION
## Summary

This PR refactors the bundler.rs file to improve code organization by extracting all module inlining functionality into a new dedicated `inliner.rs` module. This is the first step in the larger refactoring effort to split the monolithic bundler.rs file into smaller, more maintainable modules.

## Changes

- Created new `inliner.rs` module (748 lines) containing all inlining logic
- Moved `inline_module`, `inline_class`, `inline_assignment`, and `inline_ann_assignment` functions
- Extracted main inlining loop into new `inline_all_modules` function  
- Updated `bundle_modules` to use the new inliner module
- Made necessary helper methods public for cross-module access
- Reduced `bundler.rs` from 7,671 to 6,950 lines (721 lines reduction)

## Test Results

✅ All tests pass
✅ Clippy reports no warnings
✅ No functionality changes - this is a pure refactoring

## Impact

This refactoring improves code organization and maintainability without changing any functionality. The bundler logic is now better separated by concerns, making it easier to understand and modify.

## Next Steps

Future PRs will continue the refactoring by:
- Moving wrapper module processing functions to `module_transformer.rs`
- Extracting utility functions to `expression_handlers.rs`
- Creating dedicated methods for module classification and semantic analysis
- Further reducing the size of `bundler.rs` to ~3,000 lines

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Python module inlining logic into a new dedicated component for improved maintainability.
  * Enhanced symbol renaming and import alias handling to minimize conflicts during bundling.
  * Improved management of deferred imports and statement ordering for more accurate bundled outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->