### PR TITLE
refactor: use single underscore to prevent Python mangling

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -889,9 +889,7 @@ impl<'a> Bundler<'a> {
                             && assign.targets.len() == 1
                             && let Expr::Call(call) = &assign.value.as_ref()
                             && let Expr::Name(func_name) = &call.func.as_ref()
-                            && crate::code_generator::module_registry::is_init_function(
-                                func_name.id.as_str(),
-                            )
+                            && is_init_function(func_name.id.as_str())
                         {
                             // Check if the target matches our module
                             match &assign.targets[0] {
@@ -1422,9 +1420,7 @@ impl<'a> Bundler<'a> {
                         // These need to happen before any attribute accesses
                         if let Expr::Call(call) = assign.value.as_ref()
                             && let Expr::Name(func_name) = call.func.as_ref()
-                            && crate::code_generator::module_registry::is_init_function(
-                                func_name.id.as_str(),
-                            )
+                            && is_init_function(func_name.id.as_str())
                         {
                             log::debug!(
                                 "Found wrapper module initialization: {}.{} = {}()",
@@ -3925,9 +3921,7 @@ impl<'a> Bundler<'a> {
                         && let Expr::Call(call) = &expr_stmt.value.as_ref()
                         && let Expr::Name(name) = &call.func.as_ref()
                     {
-                        return !crate::code_generator::module_registry::is_init_function(
-                            name.id.as_str(),
-                        );
+                        return !is_init_function(name.id.as_str());
                     }
                     true
                 })
@@ -4343,9 +4337,7 @@ impl<'a> Bundler<'a> {
                                     // Check if this is a module init assignment
                                     if let Expr::Call(call) = &assign.value.as_ref()
                                         && let Expr::Name(func_name) = &call.func.as_ref()
-                                        && crate::code_generator::module_registry::is_init_function(
-                                            func_name.id.as_str(),
-                                        )
+                                        && is_init_function(func_name.id.as_str())
                                     {
                                         // Check in final_body for same module init
                                         final_body.iter().any(|stmt| {
@@ -4357,12 +4349,12 @@ impl<'a> Bundler<'a> {
                                                     &existing.value.as_ref()
                                                 && let Expr::Name(existing_func) =
                                                     &existing_call.func.as_ref()
-                                                && crate::code_generator::module_registry::is_init_function(
-                                                    existing_func.id.as_str()
-                                                )
+                                                && is_init_function(existing_func.id.as_str())
                                             {
                                                 let existing_path =
-                                                    expression_handlers::extract_attribute_path(existing_attr);
+                                                    expression_handlers::extract_attribute_path(
+                                                        existing_attr,
+                                                    );
                                                 if existing_path == target_path {
                                                     log::debug!(
                                                         "Found duplicate module init in \
@@ -4560,9 +4552,7 @@ impl<'a> Bundler<'a> {
                             // Check if this is a module init assignment
                             if let Expr::Call(call) = &assign.value.as_ref()
                                 && let Expr::Name(func_name) = &call.func.as_ref()
-                                && crate::code_generator::module_registry::is_init_function(
-                                    func_name.id.as_str(),
-                                )
+                                && is_init_function(func_name.id.as_str())
                             {
                                 // Check against existing deferred imports for same module init
                                 all_deferred_imports.iter().any(|existing| {
@@ -4574,9 +4564,7 @@ impl<'a> Bundler<'a> {
                                             &existing_assign.value.as_ref()
                                         && let Expr::Name(existing_func) =
                                             &existing_call.func.as_ref()
-                                        && crate::code_generator::module_registry::is_init_function(
-                                            existing_func.id.as_str(),
-                                        )
+                                        && is_init_function(existing_func.id.as_str())
                                     {
                                         let existing_path =
                                             expression_handlers::extract_attribute_path(
@@ -4695,9 +4683,7 @@ impl<'a> Bundler<'a> {
                         && let Expr::Call(call) = &expr_stmt.value.as_ref()
                         && let Expr::Name(name) = &call.func.as_ref()
                     {
-                        return !crate::code_generator::module_registry::is_init_function(
-                            name.id.as_str(),
-                        );
+                        return !is_init_function(name.id.as_str());
                     }
                     true
                 })
@@ -7422,7 +7408,7 @@ impl Bundler<'_> {
                         && let Expr::Attribute(attr) = &assign.targets[0]
                         && let Expr::Call(call) = assign.value.as_ref()
                         && let Expr::Name(func_name) = call.func.as_ref()
-                        && is_init_function(&func_name.id)
+                        && is_init_function(func_name.id.as_str())
                     {
                         // Extract the namespace path (e.g., "mypkg.compat")
                         let namespace_path = expr_to_dotted_name(&Expr::Attribute(attr.clone()));
@@ -7644,7 +7630,7 @@ impl Bundler<'_> {
                 && assign.targets.len() == 1
                 && let Expr::Call(call) = assign.value.as_ref()
                 && let Expr::Name(func_name) = call.func.as_ref()
-                && is_init_function(&func_name.id)
+                && is_init_function(func_name.id.as_str())
             {
                 if let Expr::Attribute(attr) = &assign.targets[0] {
                     let namespace_path = expr_to_dotted_name(&Expr::Attribute(attr.clone()));

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -7635,7 +7635,7 @@ impl Bundler<'_> {
         for (idx, stmt) in statements.iter().enumerate() {
             // Track namespace init function definitions
             if let Stmt::FunctionDef(func_def) = stmt
-                && is_init_function(&func_def.name)
+                && is_init_function(func_def.name.as_str())
             {
                 namespace_functions.insert(func_def.name.to_string(), idx);
             }

--- a/crates/cribo/src/code_generator/import_deduplicator.rs
+++ b/crates/cribo/src/code_generator/import_deduplicator.rs
@@ -10,8 +10,8 @@ use ruff_python_ast::{Alias, Expr, ModModule, Stmt, StmtImport, StmtImportFrom};
 
 use super::{bundler::Bundler, expression_handlers};
 use crate::{
-    cribo_graph::CriboGraph as DependencyGraph, side_effects::is_safe_stdlib_module,
-    tree_shaking::TreeShaker, types::FxIndexSet,
+    code_generator::module_registry::is_init_function, cribo_graph::CriboGraph as DependencyGraph,
+    side_effects::is_safe_stdlib_module, tree_shaking::TreeShaker, types::FxIndexSet,
 };
 
 /// Check if a statement uses importlib
@@ -423,7 +423,7 @@ pub(super) fn deduplicate_deferred_imports_with_existing(
                     && let Expr::Name(name) = &call.func.as_ref()
                 {
                     let func_name = name.id.as_str();
-                    if crate::code_generator::module_registry::is_init_function(func_name) {
+                    if is_init_function(func_name) {
                         // Use just the target path as the key for module init assignments
                         let key = target_path.clone();
                         log::debug!("Found existing module init assignment: {key} = {func_name}");
@@ -479,7 +479,7 @@ pub(super) fn deduplicate_deferred_imports_with_existing(
                 if let Expr::Call(call) = &expr_stmt.value.as_ref() {
                     if let Expr::Name(name) = &call.func.as_ref() {
                         let func_name = name.id.as_str();
-                        if crate::code_generator::module_registry::is_init_function(func_name) {
+                        if is_init_function(func_name) {
                             if seen_init_calls.insert(func_name.to_string()) {
                                 result.push(stmt);
                             } else {
@@ -509,7 +509,7 @@ pub(super) fn deduplicate_deferred_imports_with_existing(
                         && let Expr::Name(name) = &call.func.as_ref()
                     {
                         let func_name = name.id.as_str();
-                        if crate::code_generator::module_registry::is_init_function(func_name) {
+                        if is_init_function(func_name) {
                             // For module init assignments, just check the target path
                             // since the same module should only be initialized once
                             let key = target_path.clone();

--- a/crates/cribo/src/code_generator/module_registry.rs
+++ b/crates/cribo/src/code_generator/module_registry.rs
@@ -401,13 +401,14 @@ pub fn create_assignments_for_inlined_imports(
 }
 
 /// Prefix for all cribo-generated init-related names
-const CRIBO_INIT_PREFIX: &str = "__cribo_init_";
+const CRIBO_INIT_PREFIX: &str = "_cribo_init_";
 
 /// The init result variable name
 pub const INIT_RESULT_VAR: &str = "__cribo_init_result";
 
 /// The module `SimpleNamespace` variable name in init functions
-pub const MODULE_VAR: &str = "__cribo_module";
+/// Use single underscore to prevent Python mangling
+pub const MODULE_VAR: &str = "_cribo_module";
 
 /// Generate init function name from synthetic name
 pub fn get_init_function_name(synthetic_name: &str) -> String {

--- a/crates/cribo/tests/snapshots/bundled_code@all_variable_loop_reference.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@all_variable_loop_reference.snap
@@ -19,22 +19,22 @@ def my_func():
     return "Hello from my_func"
 MyClass.__module__ = 'mypkg._internal'
 @functools.cache
-def __cribo_init___cribo_4c9561_mypkg():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypkg'
-    __cribo_module.MyClass = MyClass
-    __cribo_module.my_func = my_func
+def _cribo_init___cribo_4c9561_mypkg():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypkg'
+    _cribo_module.MyClass = MyClass
+    _cribo_module.my_func = my_func
     __all__ = ["MyClass", "my_func"]
-    __locals = vars(__cribo_module)
-    __cribo_module.__locals = __locals
+    __locals = vars(_cribo_module)
+    _cribo_module.__locals = __locals
     for __name in __all__:
         if not __name.startswith("__"):
             setattr(__locals[__name], "__module__", "mypkg")
-    __cribo_module._internal = mypkg__internal
-    return __cribo_module
+    _cribo_module._internal = mypkg__internal
+    return _cribo_module
 mypkg__internal.MyClass = MyClass
 mypkg__internal.my_func = my_func
-mypkg = __cribo_init___cribo_4c9561_mypkg()
+mypkg = _cribo_init___cribo_4c9561_mypkg()
 MyClass = MyClass
 my_func = my_func
 obj = MyClass()

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_global.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_global.snap
@@ -21,35 +21,35 @@ module_global_keyword = types.SimpleNamespace(__name__='module_global_keyword', 
 _cribo_module_mixed_patterns_foo = None
 _cribo_module_mixed_patterns_counter = None
 @functools.cache
-def __cribo_init___cribo_c75306_module_mixed_patterns():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'module_mixed_patterns'
+def _cribo_init___cribo_c75306_module_mixed_patterns():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'module_mixed_patterns'
     """Module demonstrating mixed global access patterns."""
     foo = "module3_foo"
-    __cribo_module.foo = foo
+    _cribo_module.foo = foo
     bar = "module3_bar"
-    __cribo_module.bar = bar
+    _cribo_module.bar = bar
     counter = 0
-    __cribo_module.counter = counter
+    _cribo_module.counter = counter
 
     def get_values():
         """Get module globals using different methods."""
-        direct_foo = __cribo_module.foo
-        dict_bar = __cribo_module.__dict__["bar"]
-        counter_val = __cribo_module.__dict__.get("counter", -1)
+        direct_foo = _cribo_module.foo
+        dict_bar = _cribo_module.__dict__["bar"]
+        counter_val = _cribo_module.__dict__.get("counter", -1)
         return {"foo": direct_foo, "bar": dict_bar, "counter": counter_val}
-    __cribo_module.get_values = get_values
+    _cribo_module.get_values = get_values
 
     def modify_all():
         """Modify globals using different patterns."""
         global _cribo_module_mixed_patterns_foo, _cribo_module_mixed_patterns_counter
         _cribo_module_mixed_patterns_foo = "module3_foo_modified"
-        __cribo_module.foo = _cribo_module_mixed_patterns_foo
+        _cribo_module.foo = _cribo_module_mixed_patterns_foo
         _cribo_module_mixed_patterns_counter += 1
-        __cribo_module.counter = _cribo_module_mixed_patterns_counter
-        __cribo_module.__dict__["bar"] = "module3_bar_modified"
-        __cribo_module.__dict__["new_var"] = "dynamically_added"
-    __cribo_module.modify_all = modify_all
+        _cribo_module.counter = _cribo_module_mixed_patterns_counter
+        _cribo_module.__dict__["bar"] = "module3_bar_modified"
+        _cribo_module.__dict__["new_var"] = "dynamically_added"
+    _cribo_module.modify_all = modify_all
 
     def complex_global_usage():
         """Demonstrate complex global usage patterns."""
@@ -61,62 +61,62 @@ def __cribo_init___cribo_c75306_module_mixed_patterns():
         def increment():
             global _cribo_module_mixed_patterns_counter
             _cribo_module_mixed_patterns_counter += 1
-            __cribo_module.counter = _cribo_module_mixed_patterns_counter
+            _cribo_module.counter = _cribo_module_mixed_patterns_counter
             return _cribo_module_mixed_patterns_counter
-        global_keys = [k for k in __cribo_module.__dict__ if not k.startswith("_")]
+        global_keys = [k for k in _cribo_module.__dict__ if not k.startswith("_")]
         return {"original": original, "after_loop": _cribo_module_mixed_patterns_counter, "increment_func": increment, "global_count": len(global_keys)}
-    __cribo_module.complex_global_usage = complex_global_usage
-    __cribo_module.__dict__["initialized_via_globals"] = True
-    exec("exec_created_var = 'created_via_exec'", __cribo_module.__dict__)
+    _cribo_module.complex_global_usage = complex_global_usage
+    _cribo_module.__dict__["initialized_via_globals"] = True
+    exec("exec_created_var = 'created_via_exec'", _cribo_module.__dict__)
     global _cribo_module_mixed_patterns_foo
     _cribo_module_mixed_patterns_foo = foo
     global _cribo_module_mixed_patterns_counter
     _cribo_module_mixed_patterns_counter = counter
-    return __cribo_module
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_5101f4_module_globals_dict():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'module_globals_dict'
+def _cribo_init___cribo_5101f4_module_globals_dict():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'module_globals_dict'
     """Module demonstrating globals() dictionary access."""
     bar = "module2_bar"
-    __cribo_module.bar = bar
+    _cribo_module.bar = bar
     baz = 42
-    __cribo_module.baz = baz
+    _cribo_module.baz = baz
 
     def get_bar():
         """Get bar using globals() dict."""
-        return __cribo_module.__dict__["bar"]
-    __cribo_module.get_bar = get_bar
+        return _cribo_module.__dict__["bar"]
+    _cribo_module.get_bar = get_bar
 
     def modify_bar():
         """Modify bar using globals() dict."""
-        __cribo_module.__dict__["bar"] = "module2_bar_modified"
-    __cribo_module.modify_bar = modify_bar
+        _cribo_module.__dict__["bar"] = "module2_bar_modified"
+    _cribo_module.modify_bar = modify_bar
 
     def set_dynamic_global(name, value):
         """Set a global variable dynamically using globals()."""
-        __cribo_module.__dict__[name] = value
-    __cribo_module.set_dynamic_global = set_dynamic_global
+        _cribo_module.__dict__[name] = value
+    _cribo_module.set_dynamic_global = set_dynamic_global
 
     def get_dynamic_global(name, default=None):
         """Get a global variable dynamically."""
-        return __cribo_module.__dict__.get(name, default)
-    __cribo_module.get_dynamic_global = get_dynamic_global
+        return _cribo_module.__dict__.get(name, default)
+    _cribo_module.get_dynamic_global = get_dynamic_global
 
     def list_module_globals():
         """List all non-built-in globals in this module."""
-        return {k: v for k, v in __cribo_module.__dict__.items() if not k.startswith("__") and k not in ["get_bar", "modify_bar", "set_dynamic_global", "get_dynamic_global", "list_module_globals"]}
-    __cribo_module.list_module_globals = list_module_globals
+        return {k: v for k, v in _cribo_module.__dict__.items() if not k.startswith("__") and k not in ["get_bar", "modify_bar", "set_dynamic_global", "get_dynamic_global", "list_module_globals"]}
+    _cribo_module.list_module_globals = list_module_globals
     set_dynamic_global("dynamic1", "created_via_globals")
     set_dynamic_global("dynamic2", [1, 2, 3])
-    return __cribo_module
+    return _cribo_module
 """Test global namespace isolation between modules."""
 foo_1 = "main_foo"
 foo = foo_1
 bar_1 = "main_bar"
 bar = bar_1
-module_globals_dict = __cribo_init___cribo_5101f4_module_globals_dict()
-module_mixed_patterns = __cribo_init___cribo_c75306_module_mixed_patterns()
+module_globals_dict = _cribo_init___cribo_5101f4_module_globals_dict()
+module_mixed_patterns = _cribo_init___cribo_c75306_module_mixed_patterns()
 assert foo_1 == "main_foo"
 assert bar_1 == "main_bar"
 print("Module with global keyword:", module_global_keyword.get_foo())

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_globals_collision.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_globals_collision.snap
@@ -70,32 +70,32 @@ core_utils_helpers = types.SimpleNamespace(__name__='core.utils.helpers')
 core_utils.helpers = core_utils_helpers
 _cribo_models_base_Connection = None
 @functools.cache
-def __cribo_init___cribo_0a162a_models_base():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'models.base'
+def _cribo_init___cribo_0a162a_models_base():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'models.base'
     """Base models module - imports only from core to avoid circular dependencies"""
-    __cribo_module.util_validate = validate_6
+    _cribo_module.util_validate = validate_6
     util_validate = validate_6
     process = lambda x: f"base_process: {x}"
-    __cribo_module.process = process
+    _cribo_module.process = process
     validate = 123
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
     Logger = None
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
     Connection = []
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def process(data):
         """Process function in base module"""
         return f"base_process: {data} (overrides lambda)"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def validate(data):
         """Validate function that uses imported validate"""
         base_check = f"base_validate: {data}"
         util_check = util_validate(data)
         return f"{base_check} + {util_check}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class Logger:
         """Base logger class"""
@@ -106,63 +106,63 @@ def __cribo_init___cribo_0a162a_models_base():
         def get_message(self):
             return f"base_logger_{self.prefix}"
     Logger.__module__ = 'models.base'
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
 
     def initialize():
         """Initialize base module"""
         global _cribo_models_base_Connection
         _cribo_models_base_Connection = type("Connection", (), {"type": "base_connection"})
-        __cribo_module.Connection = _cribo_models_base_Connection
+        _cribo_module.Connection = _cribo_models_base_Connection
         return "base_initialized"
-    __cribo_module.initialize = initialize
+    _cribo_module.initialize = initialize
     global _cribo_models_base_Connection
     _cribo_models_base_Connection = Connection
-    return __cribo_module
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_293a98_models():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'models'
+def _cribo_init___cribo_293a98_models():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'models'
     Logger = lambda x: f"models_logger_{x}"
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
     process = "models_process"
-    __cribo_module.process = process
-    return __cribo_module
+    _cribo_module.process = process
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_1f9e6c_models_user():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'models.user'
+def _cribo_init___cribo_1f9e6c_models_user():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'models.user'
     """User models module - imports from core and base, no circular dependencies"""
-    __cribo_module.util_process = process_7
+    _cribo_module.util_process = process_7
     util_process = process_7
-    __cribo_module.UtilLogger = Logger_6
+    _cribo_module.UtilLogger = Logger_6
     UtilLogger = Logger_6
-    models.base = __cribo_init___cribo_0a162a_models_base()
+    models.base = _cribo_init___cribo_0a162a_models_base()
     BaseLogger = models.base.Logger
-    __cribo_module.BaseLogger = BaseLogger
+    _cribo_module.BaseLogger = BaseLogger
     process = "process_string"
-    __cribo_module.process = process
+    _cribo_module.process = process
     validate = {"action": "validate"}
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
     User = None
-    __cribo_module.User = User
+    _cribo_module.User = User
     Connection = type("Connection", (), {"source": "models.user"})
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def process(data):
         """Process function in user module"""
         return f"user_process: {data}"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def process_user(user_data):
         """Process user-specific data"""
         util_result = util_process(user_data)
         return f"process_user: {user_data} -> {util_result}"
-    __cribo_module.process_user = process_user
+    _cribo_module.process_user = process_user
 
     def validate(data):
         """Validate function in user module"""
         return f"user_validate: {data}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class User:
         """User model class"""
@@ -174,7 +174,7 @@ def __cribo_init___cribo_1f9e6c_models_user():
         def process(self):
             return f"User.process: {self.name}"
     User.__module__ = 'models.user'
-    __cribo_module.User = User
+    _cribo_module.User = User
 
     class Logger:
         """User module logger - different from utils and base Logger"""
@@ -190,7 +190,7 @@ def __cribo_init___cribo_1f9e6c_models_user():
         def log_all(self):
             return [self.get_message(), self.base_logger.get_message(), self.util_logger.get_message()]
     Logger.__module__ = 'models.user'
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
 
     class UserValidator:
         """Non-conflicting class name"""
@@ -201,61 +201,61 @@ def __cribo_init___cribo_1f9e6c_models_user():
         def add_rule(self, rule):
             self.rules.append(rule)
     UserValidator.__module__ = 'models.user'
-    __cribo_module.UserValidator = UserValidator
-    return __cribo_module
+    _cribo_module.UserValidator = UserValidator
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_84bf42_services_auth():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'services.auth'
+def _cribo_init___cribo_84bf42_services_auth():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'services.auth'
     Connection = lambda: "auth_package_connection"
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
     Logger = 42
-    __cribo_module.Logger = Logger
-    return __cribo_module
+    _cribo_module.Logger = Logger
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_b2dda7_services():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'services'
+def _cribo_init___cribo_b2dda7_services():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'services'
     process = lambda x, y: f"services_process: {x}, {y}"
-    __cribo_module.process = process
+    _cribo_module.process = process
     validate = "services_validate"
-    __cribo_module.validate = validate
-    return __cribo_module
+    _cribo_module.validate = validate
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_0ecebd_services_auth_manager():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'services.auth.manager'
+def _cribo_init___cribo_0ecebd_services_auth_manager():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'services.auth.manager'
     """Authentication manager - imports from core and models only, no circular dependencies"""
-    core.database.connection = __cribo_init___cribo_df9c8d_core_database_connection()
+    core.database.connection = _cribo_init___cribo_df9c8d_core_database_connection()
     DBConnection = core.database.connection.Connection
-    __cribo_module.DBConnection = DBConnection
-    __cribo_module.sanitize = sanitize
-    models.base = __cribo_init___cribo_0a162a_models_base()
+    _cribo_module.DBConnection = DBConnection
+    _cribo_module.sanitize = sanitize
+    models.base = _cribo_init___cribo_0a162a_models_base()
     base_init = models.base.initialize
-    __cribo_module.base_init = base_init
+    _cribo_module.base_init = base_init
     process = [1, 2, 3]
-    __cribo_module.process = process
+    _cribo_module.process = process
     validate = None
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
     User = "auth_user_string"
-    __cribo_module.User = User
+    _cribo_module.User = User
     Logger = set()
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
     Connection = {"auth": True}
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def process(data):
         """Process function in auth module"""
         sanitized = sanitize(data)
         return f"auth_process: {sanitized}"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def validate(data):
         """Validate function in auth module"""
         if not isinstance(data, str):
             return f"auth_validate_failed: {data}"
         return f"auth_validate: {data}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class User:
         """Auth user class"""
@@ -267,7 +267,7 @@ def __cribo_init___cribo_0ecebd_services_auth_manager():
         def authenticate(self):
             return f"auth_user_{self.username}"
     User.__module__ = 'services.auth.manager'
-    __cribo_module.User = User
+    _cribo_module.User = User
 
     class Connection:
         """Auth connection - overrides the global dict"""
@@ -280,7 +280,7 @@ def __cribo_init___cribo_0ecebd_services_auth_manager():
             db_result = self.db_conn.connect()
             return f"auth_wrapped_{db_result}"
     Connection.__module__ = 'services.auth.manager'
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     class AuthManager:
         """Non-conflicting class name"""
@@ -295,30 +295,30 @@ def __cribo_init___cribo_0ecebd_services_auth_manager():
         def process_auth(self, username, data):
             return process(f"{username}:{data}")
     AuthManager.__module__ = 'services.auth.manager'
-    __cribo_module.AuthManager = AuthManager
-    return __cribo_module
+    _cribo_module.AuthManager = AuthManager
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_df9c8d_core_database_connection():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'core.database.connection'
+def _cribo_init___cribo_df9c8d_core_database_connection():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'core.database.connection'
     """Database connection module - imports only from core.utils to avoid circular dependencies"""
     process = None
-    __cribo_module.process = process
+    _cribo_module.process = process
     validate = lambda x: f"db_validate: {x}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
     User = {"type": "database_user"}
-    __cribo_module.User = User
+    _cribo_module.User = User
 
     def process(data):
         """Process function in database module"""
         clean_data = sanitize(data)
         return f"db_process: {clean_data}"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def validate(data):
         """Validate function in database module"""
         return f"db_validate: {data} (overrides lambda)"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class Connection:
         """Database connection class"""
@@ -336,7 +336,7 @@ def __cribo_init___cribo_df9c8d_core_database_connection():
                 raise RuntimeError("Not connected")
             return format_result(f"Query: {query}")
     Connection.__module__ = 'core.database.connection'
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     class Logger:
         """Database logger - different from utils Logger"""
@@ -347,28 +347,28 @@ def __cribo_init___cribo_df9c8d_core_database_connection():
         def log(self, message):
             return f"DB_LOG[{self.context}]: {message}"
     Logger.__module__ = 'core.database.connection'
-    __cribo_module.Logger = Logger
+    _cribo_module.Logger = Logger
 
     def create_connection(db_name):
         """Factory function"""
         conn = Connection(db_name)
         conn.connect()
         return conn
-    __cribo_module.create_connection = create_connection
-    return __cribo_module
-models.base = __cribo_init___cribo_0a162a_models_base()
-services.auth.manager = __cribo_init___cribo_0ecebd_services_auth_manager()
-core.database.connection = __cribo_init___cribo_df9c8d_core_database_connection()
-models.user = __cribo_init___cribo_1f9e6c_models_user()
-__cribo_init_result = __cribo_init___cribo_84bf42_services_auth()
+    _cribo_module.create_connection = create_connection
+    return _cribo_module
+models.base = _cribo_init___cribo_0a162a_models_base()
+services.auth.manager = _cribo_init___cribo_0ecebd_services_auth_manager()
+core.database.connection = _cribo_init___cribo_df9c8d_core_database_connection()
+models.user = _cribo_init___cribo_1f9e6c_models_user()
+__cribo_init_result = _cribo_init___cribo_84bf42_services_auth()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(services.auth, attr, getattr(__cribo_init_result, attr))
-__cribo_init_result = __cribo_init___cribo_293a98_models()
+__cribo_init_result = _cribo_init___cribo_293a98_models()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(models, attr, getattr(__cribo_init_result, attr))
-__cribo_init_result = __cribo_init___cribo_b2dda7_services()
+__cribo_init_result = _cribo_init___cribo_b2dda7_services()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(services, attr, getattr(__cribo_init_result, attr))
@@ -388,8 +388,8 @@ auth_validate = services.auth.manager.validate
 UserModel = models.user.User
 process_user = models.user.process_user
 Logger = models.user.Logger
-models.base = __cribo_init___cribo_0a162a_models_base()
-__cribo_init_result = __cribo_init___cribo_293a98_models()
+models.base = _cribo_init___cribo_0a162a_models_base()
+__cribo_init_result = _cribo_init___cribo_293a98_models()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(models, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_mixed_collisions.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_mixed_collisions.snap
@@ -361,23 +361,23 @@ core_database_connection = types.SimpleNamespace(__name__='core.database.connect
 core_database.connection = core_database_connection
 _cribo_services_auth_manager_result = None
 @functools.cache
-def __cribo_init___cribo_ee1d45_services_auth_manager():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'services.auth.manager'
+def _cribo_init___cribo_ee1d45_services_auth_manager():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'services.auth.manager'
     Optional = typing.Optional
-    __cribo_module.Optional = Optional
+    _cribo_module.Optional = Optional
     Dict = typing.Dict
-    __cribo_module.Dict = Dict
+    _cribo_module.Dict = Dict
     Any = typing.Any
-    __cribo_module.Any = Any
+    _cribo_module.Any = Any
     """\nAuthentication manager with complex naming conflicts\n"""
-    __cribo_module.DBConnection = Connection_6
+    _cribo_module.DBConnection = Connection_6
     DBConnection = Connection_6
     base = models_base
     result = "auth_result"
-    __cribo_module.result = result
+    _cribo_module.result = result
     validate = lambda x: f"auth_lambda_validate: {x}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class User:
         """Auth User class - conflicts with other User classes/variables"""
@@ -405,7 +405,7 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
             self.connection = DBConnection()
             return f"User {self.username} connected"
     User.__module__ = 'services.auth.manager'
-    __cribo_module.User = User
+    _cribo_module.User = User
 
     class Connection:
         """Auth connection class - conflicts with DB Connection"""
@@ -422,7 +422,7 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
             """Process with parameter name conflicts"""
             return f"auth_connection_process: {User}"
     Connection.__module__ = 'services.auth.manager'
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def process(data: typing.Any) -> str:
         """Auth process function - major conflict"""
@@ -435,21 +435,21 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
         else:
             processed = f"auth_other_{data}"
         _cribo_services_auth_manager_result = f"{_cribo_services_auth_manager_result}_processed"
-        __cribo_module.result = _cribo_services_auth_manager_result
+        _cribo_module.result = _cribo_services_auth_manager_result
         return f"auth_processed: {processed}, base: {base_init}"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def validate(data: typing.Any) -> str:
         """Auth validate function - conflicts with other validate functions"""
         if not data:
             return "auth_invalid"
-        module_validate = __cribo_module.__dict__.get("validate")
+        module_validate = _cribo_module.__dict__.get("validate")
         if module_validate and module_validate is not validate and callable(module_validate):
             lambda_result = module_validate(data)
         else:
             lambda_result = f"fallback_{data}"
         return f"auth_valid: {data}, lambda: {lambda_result}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     def connect(User: typing.Optional["User"]=None) -> Connection:
         """Connect function with parameter conflict"""
@@ -457,7 +457,7 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
         if User:
             connection.add_user(User)
         return connection
-    __cribo_module.connect = connect
+    _cribo_module.connect = connect
 
     class AuthManager:
         """Manager class with extensive conflicts"""
@@ -477,7 +477,7 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
 
         def add_user(self, username: str, password: str) -> "User":
             """Method that creates User with local scope conflicts"""
-            User = __cribo_module.__dict__["User"]
+            User = _cribo_module.__dict__["User"]
             user = User(username, password)
             self.users.append(user)
             self.User = user
@@ -494,12 +494,12 @@ def __cribo_init___cribo_ee1d45_services_auth_manager():
                 result.append({"user": User.username, "process": user_result, "validate": validate_result, "connection": connection_process})
             return {"manager_results": result}
     AuthManager.__module__ = 'services.auth.manager'
-    __cribo_module.AuthManager = AuthManager
+    _cribo_module.AuthManager = AuthManager
     global _cribo_services_auth_manager_result
     _cribo_services_auth_manager_result = result
-    __cribo_module.base = base
-    return __cribo_module
-services.auth.manager = __cribo_init___cribo_ee1d45_services_auth_manager()
+    _cribo_module.base = base
+    return _cribo_module
+services.auth.manager = _cribo_init___cribo_ee1d45_services_auth_manager()
 core_validate = validate_6
 UserLogger = Logger_2
 util_process = process_6

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_symbols_collision.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_symbols_collision.snap
@@ -355,23 +355,23 @@ core.database = core_database
 core_database_connection = types.SimpleNamespace(__name__='core.database.connection')
 core_database.connection = core_database_connection
 @functools.cache
-def __cribo_init___cribo_6ccb3a_services_auth_manager():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'services.auth.manager'
+def _cribo_init___cribo_6ccb3a_services_auth_manager():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'services.auth.manager'
     Optional = typing.Optional
-    __cribo_module.Optional = Optional
+    _cribo_module.Optional = Optional
     Dict = typing.Dict
-    __cribo_module.Dict = Dict
+    _cribo_module.Dict = Dict
     Any = typing.Any
-    __cribo_module.Any = Any
+    _cribo_module.Any = Any
     """\nAuthentication manager with complex naming conflicts\n"""
-    __cribo_module.DBConnection = Connection_5
+    _cribo_module.DBConnection = Connection_5
     DBConnection = Connection_5
     base = models_base
     result = "auth_result"
-    __cribo_module.result = result
+    _cribo_module.result = result
     validate = lambda x: f"auth_lambda_validate: {x}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     class User:
         """Auth User class - conflicts with other User classes/variables"""
@@ -399,7 +399,7 @@ def __cribo_init___cribo_6ccb3a_services_auth_manager():
             self.connection = DBConnection()
             return f"User {self.username} connected"
     User.__module__ = 'services.auth.manager'
-    __cribo_module.User = User
+    _cribo_module.User = User
 
     class Connection:
         """Auth connection class - conflicts with DB Connection"""
@@ -416,7 +416,7 @@ def __cribo_init___cribo_6ccb3a_services_auth_manager():
             """Process with parameter name conflicts"""
             return f"auth_connection_process: {User}"
     Connection.__module__ = 'services.auth.manager'
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def process(data: typing.Any) -> str:
         """Auth process function - major conflict"""
@@ -429,19 +429,19 @@ def __cribo_init___cribo_6ccb3a_services_auth_manager():
             processed = f"auth_other_{data}"
         new_result = f"{result}_processed"
         return f"auth_processed: {processed}, base: {base_init}"
-    __cribo_module.process = process
+    _cribo_module.process = process
 
     def validate(data: typing.Any) -> str:
         """Auth validate function - conflicts with other validate functions"""
         if not data:
             return "auth_invalid"
-        module_validate = __cribo_module.validate
+        module_validate = _cribo_module.validate
         if module_validate and module_validate is not validate and callable(module_validate):
             lambda_result = module_validate(data)
         else:
             lambda_result = f"fallback_{data}"
         return f"auth_valid: {data}, lambda: {lambda_result}"
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
 
     def connect(User: typing.Optional["User"]=None) -> Connection:
         """Connect function with parameter conflict"""
@@ -449,7 +449,7 @@ def __cribo_init___cribo_6ccb3a_services_auth_manager():
         if User:
             connection.add_user(User)
         return connection
-    __cribo_module.connect = connect
+    _cribo_module.connect = connect
 
     class AuthManager:
         """Manager class with extensive conflicts"""
@@ -486,9 +486,9 @@ def __cribo_init___cribo_6ccb3a_services_auth_manager():
                 result.append({"user": User.username, "process": user_result, "validate": validate_result, "connection": connection_process})
             return {"manager_results": result}
     AuthManager.__module__ = 'services.auth.manager'
-    __cribo_module.AuthManager = AuthManager
-    __cribo_module.base = base
-    return __cribo_module
+    _cribo_module.AuthManager = AuthManager
+    _cribo_module.base = base
+    return _cribo_module
 core_validate = validate_5
 UserLogger = Logger_2
 util_process = process_5
@@ -520,7 +520,7 @@ core_database_connection.validate = validate_6
 core_database_connection.connect = connect_5
 """\nComprehensive AST rewriter test fixture - Main entry point\nThis module demonstrates complex naming conflicts and import scenarios\n"""
 db_process = process_6
-services.auth.manager = __cribo_init___cribo_6ccb3a_services_auth_manager()
+services.auth.manager = _cribo_init___cribo_6ccb3a_services_auth_manager()
 auth_process = services.auth.manager.process
 auth_validate = services.auth.manager.validate
 UserModel = User_2

--- a/crates/cribo/tests/snapshots/bundled_code@builtin_types.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@builtin_types.snap
@@ -9,30 +9,30 @@ input_file: crates/cribo/tests/fixtures/builtin_types/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_97f65c_compat_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'compat_module'
+def _cribo_init___cribo_97f65c_compat_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'compat_module'
     """Module with side effects that assigns builtin types to variables.\n\nThis minimal test case reproduces the bug where builtin types are incorrectly\ntransformed to module.str, module.int, etc. when the bundler wraps modules\nwith side effects in init functions.\n"""
     print("Loading compat module...")
     str = __import__('builtins').str
-    __cribo_module.str = str
+    _cribo_module.str = str
     int = __import__('builtins').int
-    __cribo_module.int = int
+    _cribo_module.int = int
     bytes = __import__('builtins').bytes
-    __cribo_module.bytes = bytes
+    _cribo_module.bytes = bytes
     builtin_str = __import__('builtins').str
-    __cribo_module.builtin_str = builtin_str
+    _cribo_module.builtin_str = builtin_str
     builtin_int = __import__('builtins').int
-    __cribo_module.builtin_int = builtin_int
+    _cribo_module.builtin_int = builtin_int
     builtin_bytes = __import__('builtins').bytes
-    __cribo_module.builtin_bytes = builtin_bytes
+    _cribo_module.builtin_bytes = builtin_bytes
     basestring = __import__('builtins').str, __import__('builtins').bytes
-    __cribo_module.basestring = basestring
+    _cribo_module.basestring = basestring
     numeric_types = __import__('builtins').int, float
-    __cribo_module.numeric_types = numeric_types
-    return __cribo_module
+    _cribo_module.numeric_types = numeric_types
+    return _cribo_module
 """Test that builtin type assignments work in modules with side effects."""
-compat_module = __cribo_init___cribo_97f65c_compat_module()
+compat_module = _cribo_init___cribo_97f65c_compat_module()
 builtin_str = compat_module.builtin_str
 builtin_int = compat_module.builtin_int
 basestring = compat_module.basestring

--- a/crates/cribo/tests/snapshots/bundled_code@circular_dep_with_version_module.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@circular_dep_with_version_module.snap
@@ -16,31 +16,31 @@ package.module_a = package_module_a
 __version__ = "1.0.0"
 __title__ = "Test Package"
 def func_a():
-    package = __cribo_init___cribo_a4c23d_package()
+    package = _cribo_init___cribo_a4c23d_package()
     return "func_a"
 """Module A that creates circular dependency"""
 """Version information for the package"""
 @functools.cache
-def __cribo_init___cribo_a4c23d_package():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'package'
+def _cribo_init___cribo_a4c23d_package():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'package'
     """Package with circular dependency and __version__ import"""
-    __cribo_module.__version__ = __version__
-    __cribo_module.__title__ = __title__
-    __cribo_module.func_a = func_a
+    _cribo_module.__version__ = __version__
+    _cribo_module.__title__ = __title__
+    _cribo_module.func_a = func_a
 
     def package_func():
         return func_a() + " from package"
-    __cribo_module.package_func = package_func
+    _cribo_module.package_func = package_func
     print(f"Package initialized with version {__version__}")
-    __cribo_module.module_a = package_module_a
-    return __cribo_module
-package = __cribo_init___cribo_a4c23d_package()
+    _cribo_module.module_a = package_module_a
+    return _cribo_module
+package = _cribo_init___cribo_a4c23d_package()
 package_module_a.func_a = func_a
 package___version__.__version__ = __version__
 package___version__.__title__ = __title__
 """Test case for circular dependency with __version__ module import"""
-package = __cribo_init___cribo_a4c23d_package()
+package = _cribo_init___cribo_a4c23d_package()
 print(f"Package version: {package.__version__}")
 print(f"Package title: {package.__title__}")
 print("Success!")

--- a/crates/cribo/tests/snapshots/bundled_code@circular_deps_with_stdlib_name_conflict.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@circular_deps_with_stdlib_name_conflict.snap
@@ -12,14 +12,14 @@ import types
 import typing
 pkg = types.SimpleNamespace(__name__='pkg')
 @functools.cache
-def __cribo_init___cribo_2353ad_pkg_pretty():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg.pretty'
+def _cribo_init___cribo_2353ad_pkg_pretty():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg.pretty'
     Any = typing.Any
-    __cribo_module.Any = Any
+    _cribo_module.Any = Any
     """Pretty printing module with circular dependency on console."""
-    __cribo_module.RichRenderable = RichRenderable
-    __cribo_module.Console = Console
+    _cribo_module.RichRenderable = RichRenderable
+    _cribo_module.Console = Console
 
     class PrettyPrinter(RichRenderable):
         """Pretty printer that implements RichRenderable."""
@@ -37,15 +37,15 @@ def __cribo_init___cribo_2353ad_pkg_pretty():
             formatted = format_pretty(obj, console)
             print(formatted)
     PrettyPrinter.__module__ = 'pkg.pretty'
-    __cribo_module.PrettyPrinter = PrettyPrinter
+    _cribo_module.PrettyPrinter = PrettyPrinter
 
     def format_pretty(obj: typing.Any, console: Console) -> str:
         """Format object for pretty printing."""
         if console.is_renderable(obj):
             return f"<Renderable: {obj}>"
         return repr(obj)
-    __cribo_module.format_pretty = format_pretty
-    return __cribo_module
+    _cribo_module.format_pretty = format_pretty
+    return _cribo_module
 abstractmethod = abc.abstractmethod
 class RichRenderable(abc.ABC):
     """Abstract base class for renderables."""
@@ -144,7 +144,7 @@ pkg_color = types.SimpleNamespace(__name__='pkg.color')
 pkg.color = pkg_color
 pkg_style = types.SimpleNamespace(__name__='pkg.style')
 pkg.style = pkg_style
-pkg.pretty = __cribo_init___cribo_2353ad_pkg_pretty()
+pkg.pretty = _cribo_init___cribo_2353ad_pkg_pretty()
 pkg_abc.RichRenderable = RichRenderable
 pkg_abc.abstractmethod = abstractmethod
 pkg_console.format_with_pretty = format_with_pretty

--- a/crates/cribo/tests/snapshots/bundled_code@collections_abc_wrapper.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@collections_abc_wrapper.snap
@@ -10,17 +10,17 @@ import collections.abc
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_f0aa89_compat():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'compat'
+def _cribo_init___cribo_f0aa89_compat():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'compat'
     MutableMapping = collections.abc.MutableMapping
-    __cribo_module.MutableMapping = MutableMapping
+    _cribo_module.MutableMapping = MutableMapping
     Mapping = collections.abc.Mapping
-    __cribo_module.Mapping = Mapping
+    _cribo_module.Mapping = Mapping
     """compat.py - Compatibility module with side effects."""
     print("Loading compat module...")
-    return __cribo_module
-compat = __cribo_init___cribo_f0aa89_compat()
+    return _cribo_module
+compat = _cribo_init___cribo_f0aa89_compat()
 class CaseInsensitiveDict(compat.MutableMapping):
     """A case-insensitive dict-like object."""
 

--- a/crates/cribo/tests/snapshots/bundled_code@conditional_exports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@conditional_exports.snap
@@ -16,32 +16,32 @@ BaseError.__module__ = 'exceptions_module'
 """Module that uses imports from compat_module (like requests.exceptions)."""
 exceptions_module = types.SimpleNamespace(__name__='exceptions_module', BaseError=BaseError)
 @functools.cache
-def __cribo_init___cribo_244765_compat_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'compat_module'
+def _cribo_init___cribo_244765_compat_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'compat_module'
     """\nModule that mimics requests.compat structure.\nNo __all__ defined, so all non-underscore symbols should be exported.\n"""
     _ver = sys.version_info
-    __cribo_module._ver = _ver
+    _cribo_module._ver = _ver
     is_py2 = _ver[0] == 2
-    __cribo_module.is_py2 = is_py2
+    _cribo_module.is_py2 = is_py2
     is_py3 = _ver[0] == 3
-    __cribo_module.is_py3 = is_py3
+    _cribo_module.is_py3 = is_py3
     has_simplejson = False
-    __cribo_module.has_simplejson = has_simplejson
+    _cribo_module.has_simplejson = has_simplejson
     try:
         import simplejson as json
-        __cribo_module.json = json
+        _cribo_module.json = json
         has_simplejson = True
-        __cribo_module.has_simplejson = has_simplejson
+        _cribo_module.has_simplejson = has_simplejson
     except ImportError:
         import json
-        __cribo_module.json = json
+        _cribo_module.json = json
     if has_simplejson:
         from simplejson import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     else:
         from json import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
 
     def _resolve_char_detection():
         """Find supported character detection libraries."""
@@ -53,23 +53,23 @@ def __cribo_init___cribo_244765_compat_module():
                 except ImportError:
                     pass
         return chardet
-    __cribo_module._resolve_char_detection = _resolve_char_detection
+    _cribo_module._resolve_char_detection = _resolve_char_detection
     chardet = _resolve_char_detection()
-    __cribo_module.chardet = chardet
+    _cribo_module.chardet = chardet
     builtin_str = str
-    __cribo_module.builtin_str = builtin_str
+    _cribo_module.builtin_str = builtin_str
     basestring = str, bytes
-    __cribo_module.basestring = basestring
+    _cribo_module.basestring = basestring
     _internal_cache = {}
-    __cribo_module._internal_cache = _internal_cache
+    _cribo_module._internal_cache = _internal_cache
 
     def get_encoding_from_headers(headers):
         """Dummy function to test function exports."""
         return "utf-8"
-    __cribo_module.get_encoding_from_headers = get_encoding_from_headers
-    return __cribo_module
+    _cribo_module.get_encoding_from_headers = get_encoding_from_headers
+    return _cribo_module
 """Test conditional imports and exports without explicit __all__."""
-compat_module = __cribo_init___cribo_244765_compat_module()
+compat_module = _cribo_init___cribo_244765_compat_module()
 print("compat_module has JSONDecodeError:", hasattr(compat_module, "JSONDecodeError"))
 if hasattr(compat_module, "JSONDecodeError"):
     print("✓ Can access compat_module.JSONDecodeError")

--- a/crates/cribo/tests/snapshots/bundled_code@conditional_imports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@conditional_imports.snap
@@ -10,98 +10,98 @@ import functools
 import sys
 import types
 @functools.cache
-def __cribo_init___cribo_17f1ec_try_except_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'try_except_module'
+def _cribo_init___cribo_17f1ec_try_except_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'try_except_module'
     """Module with imports inside try/except blocks."""
     etree = None
-    __cribo_module.etree = etree
+    _cribo_module.etree = etree
     ETREE_VERSION = None
-    __cribo_module.ETREE_VERSION = ETREE_VERSION
+    _cribo_module.ETREE_VERSION = ETREE_VERSION
     try:
         from lxml import etree
-        __cribo_module.etree = etree
+        _cribo_module.etree = etree
         ETREE_VERSION = "lxml"
-        __cribo_module.ETREE_VERSION = ETREE_VERSION
+        _cribo_module.ETREE_VERSION = ETREE_VERSION
     except ImportError:
         try:
             import xml.etree.ElementTree as etree
-            __cribo_module.etree = etree
+            _cribo_module.etree = etree
             ETREE_VERSION = "stdlib"
-            __cribo_module.ETREE_VERSION = ETREE_VERSION
+            _cribo_module.ETREE_VERSION = ETREE_VERSION
         except ImportError:
             etree = None
-            __cribo_module.etree = etree
+            _cribo_module.etree = etree
             ETREE_VERSION = None
-            __cribo_module.ETREE_VERSION = ETREE_VERSION
+            _cribo_module.ETREE_VERSION = ETREE_VERSION
     parser_backend = None
-    __cribo_module.parser_backend = parser_backend
+    _cribo_module.parser_backend = parser_backend
     try:
         import cElementTree as ET
-        __cribo_module.ET = ET
+        _cribo_module.ET = ET
         parser_backend = "cElementTree"
-        __cribo_module.parser_backend = parser_backend
+        _cribo_module.parser_backend = parser_backend
     except ImportError:
         try:
             import xml.etree.ElementTree as ET
-            __cribo_module.ET = ET
+            _cribo_module.ET = ET
             parser_backend = "ElementTree"
-            __cribo_module.parser_backend = parser_backend
+            _cribo_module.parser_backend = parser_backend
         except ImportError:
             ET = None
-            __cribo_module.ET = ET
+            _cribo_module.ET = ET
             parser_backend = None
-            __cribo_module.parser_backend = parser_backend
+            _cribo_module.parser_backend = parser_backend
 
     def parse_xml(xml_string):
         """Parse XML using available parser."""
         if etree is not None:
-            return __cribo_module.etree.fromstring(xml_string)
+            return _cribo_module.etree.fromstring(xml_string)
         elif ET is not None:
             return ET.fromstring(xml_string)
         else:
             raise ImportError("No XML parser available")
-    __cribo_module.parse_xml = parse_xml
-    return __cribo_module
+    _cribo_module.parse_xml = parse_xml
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_e43fad_conditional_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'conditional_module'
+def _cribo_init___cribo_e43fad_conditional_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'conditional_module'
     """Module with conditional imports inside if/else blocks."""
     has_simplejson = False
-    __cribo_module.has_simplejson = has_simplejson
+    _cribo_module.has_simplejson = has_simplejson
     try:
         import simplejson as json
-        __cribo_module.json = json
+        _cribo_module.json = json
         has_simplejson = True
-        __cribo_module.has_simplejson = has_simplejson
+        _cribo_module.has_simplejson = has_simplejson
     except ImportError:
         import json
-        __cribo_module.json = json
+        _cribo_module.json = json
     if has_simplejson:
         from simplejson import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     else:
         from json import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     if sys.version_info[0] >= 3:
         builtin_str = str
-        __cribo_module.builtin_str = builtin_str
+        _cribo_module.builtin_str = builtin_str
         my_str = str
-        __cribo_module.my_str = my_str
+        _cribo_module.my_str = my_str
     else:
         builtin_str = str
-        __cribo_module.builtin_str = builtin_str
+        _cribo_module.builtin_str = builtin_str
         my_str = unicode
-        __cribo_module.my_str = my_str
+        _cribo_module.my_str = my_str
     basestring = str, bytes
-    __cribo_module.basestring = basestring
+    _cribo_module.basestring = basestring
     if has_simplejson:
         if hasattr(json, "JSONDecodeError"):
             pass
         else:
             JSONDecodeError = ValueError
-            __cribo_module.JSONDecodeError = JSONDecodeError
+            _cribo_module.JSONDecodeError = JSONDecodeError
     else:
         pass
 
@@ -111,11 +111,11 @@ def __cribo_init___cribo_e43fad_conditional_module():
             return json.loads(text)
         except JSONDecodeError as e:
             return None
-    __cribo_module.decode_json = decode_json
-    return __cribo_module
+    _cribo_module.decode_json = decode_json
+    return _cribo_module
 """Test conditional imports in if/else and try/except blocks."""
-conditional_module = __cribo_init___cribo_e43fad_conditional_module()
-try_except_module = __cribo_init___cribo_17f1ec_try_except_module()
+conditional_module = _cribo_init___cribo_e43fad_conditional_module()
+try_except_module = _cribo_init___cribo_17f1ec_try_except_module()
 print("If/else import - JSONDecodeError:", hasattr(conditional_module, "JSONDecodeError"))
 print("If/else import - json:", hasattr(conditional_module, "json"))
 print("If/else import - builtin_str:", hasattr(conditional_module, "builtin_str"))

--- a/crates/cribo/tests/snapshots/bundled_code@cross_module_attribute_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@cross_module_attribute_import.snap
@@ -10,19 +10,19 @@ import functools
 import types
 mypackage = types.SimpleNamespace(__name__='mypackage')
 @functools.cache
-def __cribo_init___cribo_35f1d1_mypackage_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.utils'
+def _cribo_init___cribo_35f1d1_mypackage_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.utils'
     """Utils module that imports from __version__ module and uses it at module level."""
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
     VERSION_PREFIX = f"v{__version__}"
-    __cribo_module.VERSION_PREFIX = VERSION_PREFIX
+    _cribo_module.VERSION_PREFIX = VERSION_PREFIX
 
     def get_version_info():
         """Return version information using the imported __version__ variable."""
-        return __cribo_module.VERSION_PREFIX
-    __cribo_module.get_version_info = get_version_info
-    return __cribo_module
+        return _cribo_module.VERSION_PREFIX
+    _cribo_module.get_version_info = get_version_info
+    return _cribo_module
 __version__ = "1.0.0"
 def get_full_info():
     """Combine version and processed data."""
@@ -38,7 +38,7 @@ mypackage_core = types.SimpleNamespace(__name__='mypackage.core')
 mypackage.core = mypackage_core
 mypackage___version__ = types.SimpleNamespace(__name__='mypackage.__version__')
 mypackage.__version__ = mypackage___version__
-mypackage.utils = __cribo_init___cribo_35f1d1_mypackage_utils()
+mypackage.utils = _cribo_init___cribo_35f1d1_mypackage_utils()
 mypackage_core.process_data = process_data
 mypackage___version__.__version__ = __version__
 """Test cross-module attribute import with circular dependencies that require init functions."""

--- a/crates/cribo/tests/snapshots/bundled_code@cross_module_import_attribute.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@cross_module_import_attribute.snap
@@ -10,31 +10,31 @@ import functools
 import types
 my_package = types.SimpleNamespace(__name__='my_package')
 @functools.cache
-def __cribo_init___cribo_699da1_my_package___version__():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my_package.__version__'
+def _cribo_init___cribo_699da1_my_package___version__():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my_package.__version__'
     """Version information for my_package"""
     __version__ = "1.2.3"
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
     print("Loading version module...")
-    return __cribo_module
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_1f0580_my_package_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my_package.utils'
+def _cribo_init___cribo_1f0580_my_package_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my_package.utils'
     """Utility module that imports version from another module"""
-    my_package.__version__ = __cribo_init___cribo_699da1_my_package___version__()
+    my_package.__version__ = _cribo_init___cribo_699da1_my_package___version__()
     __version__ = my_package.__version__.__version__
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
     print("Loading utils module...")
 
     def get_version():
         """Return the package version"""
         return __version__
-    __cribo_module.get_version = get_version
-    return __cribo_module
+    _cribo_module.get_version = get_version
+    return _cribo_module
 """Test cross-module attribute imports like requests.__version__"""
-my_package.utils = __cribo_init___cribo_1f0580_my_package_utils()
+my_package.utils = _cribo_init___cribo_1f0580_my_package_utils()
 utils = my_package.utils
 print(f"Version from utils: {utils.get_version()}")
 print(f"Direct __version__ access: {utils.__version__}")

--- a/crates/cribo/tests/snapshots/bundled_code@cross_package_mixed_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@cross_package_mixed_import.snap
@@ -68,112 +68,112 @@ _cribo_core__initialized = None
 _cribo_core__config = None
 _cribo_models__base_model = None
 @functools.cache
-def __cribo_init___cribo_f00e4b_core():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'core'
+def _cribo_init___cribo_f00e4b_core():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'core'
     """Core package with initialization logic and cross-package imports."""
     _initialized = False
-    __cribo_module._initialized = _initialized
+    _cribo_module._initialized = _initialized
     _config = {"debug": False}
-    __cribo_module._config = _config
-    __cribo_module.CORE_MODEL_VERSION = CORE_MODEL_VERSION
-    __cribo_module.validate = validate
-    __cribo_module.get_config = get_config
-    __cribo_module.set_config_reference = set_config_reference
+    _cribo_module._config = _config
+    _cribo_module.CORE_MODEL_VERSION = CORE_MODEL_VERSION
+    _cribo_module.validate = validate
+    _cribo_module.get_config = get_config
+    _cribo_module.set_config_reference = set_config_reference
     set_config_reference(_config)
 
     def initialize_core(debug=False):
         """Initialize the core package with configuration."""
         global _cribo_core__initialized, _cribo_core__config
         _cribo_core__initialized = True
-        __cribo_module._initialized = _cribo_core__initialized
+        _cribo_module._initialized = _cribo_core__initialized
         _cribo_core__config["debug"] = debug
         if debug:
             print(f"Core initialized with version: {CORE_MODEL_VERSION}")
         return _cribo_core__initialized
-    __cribo_module.initialize_core = initialize_core
+    _cribo_module.initialize_core = initialize_core
 
     def is_initialized():
         """Check if core is initialized."""
-        return __cribo_module._initialized
-    __cribo_module.is_initialized = is_initialized
+        return _cribo_module._initialized
+    _cribo_module.is_initialized = is_initialized
     global _cribo_core__initialized
     _cribo_core__initialized = _initialized
     global _cribo_core__config
     _cribo_core__config = _config
-    __cribo_module.version = core_version
-    __cribo_module.utils = core_utils
-    return __cribo_module
+    _cribo_module.version = core_version
+    _cribo_module.utils = core_utils
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_563ea2_models():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'models'
+def _cribo_init___cribo_563ea2_models():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'models'
     """Models package with conditional imports and circular dependency handling."""
     _VERSION = "1.0.0"
-    __cribo_module._VERSION = _VERSION
+    _cribo_module._VERSION = _VERSION
 
     def get_model_version():
         """Get the models package version."""
-        return __cribo_module._VERSION
-    __cribo_module.get_model_version = get_model_version
+        return _cribo_module._VERSION
+    _cribo_module.get_model_version = get_model_version
     if sys.version_info >= (3, 9):
         from typing import TypeAlias
-        __cribo_module.TypeAlias = TypeAlias
+        _cribo_module.TypeAlias = TypeAlias
         ModelID: TypeAlias = str
     else:
         ModelID = str
-        __cribo_module.ModelID = ModelID
+        _cribo_module.ModelID = ModelID
     _base_model = None
-    __cribo_module._base_model = _base_model
+    _cribo_module._base_model = _base_model
 
     def get_base_model():
         """Lazy import of BaseModel to avoid circular imports."""
         global _cribo_models__base_model
         if _cribo_models__base_model is None:
-            __cribo_module.BaseModel = BaseModel
+            _cribo_module.BaseModel = BaseModel
             _cribo_models__base_model = BaseModel
         return _cribo_models__base_model
-    __cribo_module.get_base_model = get_base_model
-    __cribo_module.process_user = process_user
+    _cribo_module.get_base_model = get_base_model
+    _cribo_module.process_user = process_user
     DEFAULT_MODEL_CONFIG = {"version": _VERSION, "features": ["user_processing", "lazy_loading"]}
-    __cribo_module.DEFAULT_MODEL_CONFIG = DEFAULT_MODEL_CONFIG
+    _cribo_module.DEFAULT_MODEL_CONFIG = DEFAULT_MODEL_CONFIG
     try:
         from models.advanced import AdvancedModel
-        __cribo_module.AdvancedModel = AdvancedModel
+        _cribo_module.AdvancedModel = AdvancedModel
         HAS_ADVANCED = True
-        __cribo_module.HAS_ADVANCED = HAS_ADVANCED
+        _cribo_module.HAS_ADVANCED = HAS_ADVANCED
         DEFAULT_MODEL_CONFIG["features"].append("advanced_model")
     except ImportError:
         HAS_ADVANCED = False
-        __cribo_module.HAS_ADVANCED = HAS_ADVANCED
+        _cribo_module.HAS_ADVANCED = HAS_ADVANCED
         AdvancedModel = None
-        __cribo_module.AdvancedModel = AdvancedModel
+        _cribo_module.AdvancedModel = AdvancedModel
     __all__ = ["get_model_version", "process_user", "get_base_model", "ModelID", "DEFAULT_MODEL_CONFIG", "HAS_ADVANCED"]
     if HAS_ADVANCED:
         __all__.append("AdvancedModel")
     global _cribo_models__base_model
     _cribo_models__base_model = _base_model
-    __cribo_module.user = models_user
-    __cribo_module.base = models_base
-    return __cribo_module
+    _cribo_module.user = models_user
+    _cribo_module.base = models_base
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_1f0c3d_core_database_connection():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'core.database.connection'
+def _cribo_init___cribo_1f0c3d_core_database_connection():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'core.database.connection'
     """Database connection module demonstrating mixed import patterns.\n\nThis module combines:\n1. Absolute import from a different package (models.user)\n2. Relative import from within the same package (..utils.helpers)\n3. Import from parent package's version module (not __init__.py)\n4. No imports from parent package's __init__.py to avoid circular dependencies\n"""
-    __cribo_module.process_user = process_user
-    __cribo_module.helper_validate = validate
+    _cribo_module.process_user = process_user
+    _cribo_module.helper_validate = validate
     helper_validate = validate
-    __cribo_module.CORE_MODEL_VERSION = CORE_MODEL_VERSION
-    models = __cribo_init___cribo_563ea2_models()
+    _cribo_module.CORE_MODEL_VERSION = CORE_MODEL_VERSION
+    models = _cribo_init___cribo_563ea2_models()
     DEFAULT_MODEL_CONFIG = models.DEFAULT_MODEL_CONFIG
-    __cribo_module.DEFAULT_MODEL_CONFIG = DEFAULT_MODEL_CONFIG
+    _cribo_module.DEFAULT_MODEL_CONFIG = DEFAULT_MODEL_CONFIG
     get_base_model = models.get_base_model
-    __cribo_module.get_base_model = get_base_model
+    _cribo_module.get_base_model = get_base_model
     _connection_types = ["standard", "pooled", "async"]
-    __cribo_module._connection_types = _connection_types
+    _cribo_module._connection_types = _connection_types
     CONNECTION_METADATA = {"supported_types": _connection_types, "validator": helper_validate.__name__, "processor": process_user.__name__, "core_version": CORE_MODEL_VERSION, "model_config": DEFAULT_MODEL_CONFIG}
-    __cribo_module.CONNECTION_METADATA = CONNECTION_METADATA
+    _cribo_module.CONNECTION_METADATA = CONNECTION_METADATA
 
     class Connection:
         """Connection class using mixed imports."""
@@ -191,38 +191,38 @@ def __cribo_init___cribo_1f0c3d_core_database_connection():
         def __str__(self):
             return f"Connection to {self.name}"
     Connection.__module__ = 'core.database.connection'
-    __cribo_module.Connection = Connection
+    _cribo_module.Connection = Connection
 
     def connect(database_name: str) -> Connection:
         """Create a new database connection."""
         return Connection(database_name)
-    __cribo_module.connect = connect
+    _cribo_module.connect = connect
 
     def get_connection_info() -> dict:
         """Get general connection information."""
-        __cribo_module.is_debug = is_debug
-        info = {"metadata": __cribo_module.CONNECTION_METADATA, "debug_mode": is_debug(), "available_validators": ["validate_db_name", helper_validate.__name__]}
+        _cribo_module.is_debug = is_debug
+        info = {"metadata": _cribo_module.CONNECTION_METADATA, "debug_mode": is_debug(), "available_validators": ["validate_db_name", helper_validate.__name__]}
         if is_debug():
-            __cribo_module.get_full_config = get_config
+            _cribo_module.get_full_config = get_config
             get_full_config = get_config
             info["config"] = get_full_config()
         return info
-    __cribo_module.get_connection_info = get_connection_info
-    return __cribo_module
+    _cribo_module.get_connection_info = get_connection_info
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_782908_core_database():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'core.database'
+def _cribo_init___cribo_782908_core_database():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'core.database'
     """Database subpackage with import-time initialization and re-exports."""
-    __cribo_module.validate = validate
+    _cribo_module.validate = validate
     _registered_types = []
-    __cribo_module._registered_types = _registered_types
+    _cribo_module._registered_types = _registered_types
 
     def _register_type(type_name):
         """Internal function to register database types."""
-        __cribo_module._registered_types.append(type_name)
+        _cribo_module._registered_types.append(type_name)
         return type_name
-    __cribo_module._register_type = _register_type
+    _cribo_module._register_type = _register_type
     _register_type("connection")
     _register_type("cursor")
 
@@ -231,16 +231,16 @@ def __cribo_init___cribo_782908_core_database():
         if not validate(name):
             return False
         return not any(char in name for char in ["/", "\\", ":"])
-    __cribo_module.validate_db_name = validate_db_name
-    core.database.connection = __cribo_init___cribo_1f0c3d_core_database_connection()
+    _cribo_module.validate_db_name = validate_db_name
+    core.database.connection = _cribo_init___cribo_1f0c3d_core_database_connection()
     connect = core.database.connection.connect
-    __cribo_module.connect = connect
+    _cribo_module.connect = connect
     get_connection_info = core.database.connection.get_connection_info
-    __cribo_module.get_connection_info = get_connection_info
+    _cribo_module.get_connection_info = get_connection_info
 
     def safe_connect(database_name: str) -> str:
         """Connect only if core is initialized."""
-        __cribo_init_result = __cribo_init___cribo_f00e4b_core()
+        __cribo_init_result = _cribo_init___cribo_f00e4b_core()
         for attr in dir(__cribo_init_result):
             if not attr.startswith('_'):
                 setattr(core, attr, getattr(__cribo_init_result, attr))
@@ -248,8 +248,8 @@ def __cribo_init___cribo_782908_core_database():
         if not is_initialized():
             raise RuntimeError("Core package must be initialized before connecting")
         return connect(database_name)
-    __cribo_module.safe_connect = safe_connect
-    return __cribo_module
+    _cribo_module.safe_connect = safe_connect
+    return _cribo_module
 models_user.process_user = process_user
 models_base.BaseModel = BaseModel
 core_utils_config.set_config_reference = set_config_reference
@@ -258,25 +258,25 @@ core_utils_config.is_debug = is_debug
 core_version.CORE_MODEL_VERSION = CORE_MODEL_VERSION
 core_utils_helpers.validate = validate
 """Test fixture demonstrating cross-package mixed import patterns.\n\nThis tests the specific pattern where a module uses both:\n1. Deep absolute imports crossing package boundaries (e.g., from models.user)\n2. Relative imports within its package (e.g., from ..utils.helpers)\n3. Import order dependencies with __init__.py files\n"""
-__cribo_init_result = __cribo_init___cribo_f00e4b_core()
+__cribo_init_result = _cribo_init___cribo_f00e4b_core()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(core, attr, getattr(__cribo_init_result, attr))
 initialize_core = core.initialize_core
-__cribo_init_result = __cribo_init___cribo_782908_core_database()
+__cribo_init_result = _cribo_init___cribo_782908_core_database()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(core.database, attr, getattr(__cribo_init_result, attr))
 db_connect = core.database.connect
-core.database.connection = __cribo_init___cribo_1f0c3d_core_database_connection()
+core.database.connection = _cribo_init___cribo_1f0c3d_core_database_connection()
 connect = core.database.connection.connect
 get_connection_info = core.database.connection.get_connection_info
 CONNECTION_METADATA = core.database.connection.CONNECTION_METADATA
-models = __cribo_init___cribo_563ea2_models()
+models = _cribo_init___cribo_563ea2_models()
 get_model_version = models.get_model_version
 DEFAULT_MODEL_CONFIG = models.DEFAULT_MODEL_CONFIG
 HAS_ADVANCED = models.HAS_ADVANCED
-__cribo_init_result = __cribo_init___cribo_f00e4b_core()
+__cribo_init_result = _cribo_init___cribo_f00e4b_core()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(core, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_import_before_init.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_import_before_init.snap
@@ -14,19 +14,19 @@ class BaseException(Exception):
     """Base exception class"""
     pass
 @functools.cache
-def __cribo_init___cribo_4089db_mypkg_compat():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypkg.compat'
+def _cribo_init___cribo_4089db_mypkg_compat():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypkg.compat'
     try:
         from fakejson import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     except ImportError:
         from json import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     MutableMapping = collections.abc.MutableMapping
-    __cribo_module.MutableMapping = MutableMapping
-    return __cribo_module
-mypkg.compat = __cribo_init___cribo_4089db_mypkg_compat()
+    _cribo_module.MutableMapping = MutableMapping
+    return _cribo_module
+mypkg.compat = _cribo_init___cribo_4089db_mypkg_compat()
 class CustomJSONError(BaseException, mypkg.compat.JSONDecodeError):
     """Custom JSON error that inherits from compat's JSONDecodeError"""
 
@@ -40,7 +40,7 @@ BaseException.__module__ = 'mypkg.exceptions'
 CustomJSONError.__module__ = 'mypkg.exceptions'
 mypkg_exceptions = types.SimpleNamespace(__name__='mypkg.exceptions')
 mypkg.exceptions = mypkg_exceptions
-mypkg.compat = __cribo_init___cribo_4089db_mypkg_compat()
+mypkg.compat = _cribo_init___cribo_4089db_mypkg_compat()
 JSONDecodeError = mypkg.compat.JSONDecodeError
 mypkg_exceptions.BaseException = BaseException
 mypkg_exceptions.CustomJSONError = CustomJSONError

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
@@ -21,40 +21,40 @@ class InvalidJSONError(RequestException):
     """A JSON error occurred."""
     pass
 @functools.cache
-def __cribo_init___cribo_5ad29b_myrequests_compat():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'myrequests.compat'
+def _cribo_init___cribo_5ad29b_myrequests_compat():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'myrequests.compat'
     urlparse = urllib.parse.urlparse
-    __cribo_module.urlparse = urlparse
+    _cribo_module.urlparse = urlparse
     urlunparse = urllib.parse.urlunparse
-    __cribo_module.urlunparse = urlunparse
+    _cribo_module.urlunparse = urlunparse
     urljoin = urllib.parse.urljoin
-    __cribo_module.urljoin = urljoin
+    _cribo_module.urljoin = urljoin
     cookielib = http.cookiejar
-    __cribo_module.cookielib = cookielib
+    _cribo_module.cookielib = cookielib
     MutableMapping = collections.abc.MutableMapping
-    __cribo_module.MutableMapping = MutableMapping
+    _cribo_module.MutableMapping = MutableMapping
     Mapping = collections.abc.Mapping
-    __cribo_module.Mapping = Mapping
+    _cribo_module.Mapping = Mapping
     """Compat module that provides base classes and utilities used by other modules."""
     try:
         import simplejson as json
-        __cribo_module.json = json
+        _cribo_module.json = json
     except ImportError:
         import json
-        __cribo_module.json = json
+        _cribo_module.json = json
     if hasattr(json, "JSONDecodeError"):
         JSONDecodeError = json.JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     else:
         JSONDecodeError = ValueError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     builtin_str = str
-    __cribo_module.builtin_str = builtin_str
+    _cribo_module.builtin_str = builtin_str
     basestring = str, bytes
-    __cribo_module.basestring = basestring
-    return __cribo_module
-myrequests.compat = __cribo_init___cribo_5ad29b_myrequests_compat()
+    _cribo_module.basestring = basestring
+    return _cribo_module
+myrequests.compat = _cribo_init___cribo_5ad29b_myrequests_compat()
 class JSONDecodeError(InvalidJSONError, myrequests.compat.JSONDecodeError):
     """Couldn't decode the text into json."""
     pass
@@ -111,7 +111,7 @@ myrequests_exceptions = types.SimpleNamespace(__name__='myrequests.exceptions')
 myrequests.exceptions = myrequests_exceptions
 myrequests_cookies = types.SimpleNamespace(__name__='myrequests.cookies')
 myrequests.cookies = myrequests_cookies
-myrequests.compat = __cribo_init___cribo_5ad29b_myrequests_compat()
+myrequests.compat = _cribo_init___cribo_5ad29b_myrequests_compat()
 CompatJSONDecodeError = myrequests.compat.JSONDecodeError
 cookielib = myrequests.compat.cookielib
 MutableMapping = myrequests.compat.MutableMapping

--- a/crates/cribo/tests/snapshots/bundled_code@future_imports_basic.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@future_imports_basic.snap
@@ -16,59 +16,59 @@ mypackage.submodule = mypackage_submodule
 """Submodule with future imports."""
 """Package initialization with future import."""
 @functools.cache
-def __cribo_init___cribo_c3d681_mypackage_submodule_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.submodule.utils'
+def _cribo_init___cribo_c3d681_mypackage_submodule_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.submodule.utils'
     Dict = typing.Dict
-    __cribo_module.Dict = Dict
+    _cribo_module.Dict = Dict
     Any = typing.Any
-    __cribo_module.Any = Any
+    _cribo_module.Any = Any
     Union = typing.Union
-    __cribo_module.Union = Union
+    _cribo_module.Union = Union
 
     def validate_input(data: InputData) -> bool:
         """Validate input data structure.\n\n    Uses forward reference that requires future import.\n    """
         if not isinstance(data, dict):
             return False
         return "key" in data and isinstance(data.get("numbers"), list)
-    __cribo_module.validate_input = validate_input
+    _cribo_module.validate_input = validate_input
 
     def format_output(data: typing.Any) -> FormattedOutput:
         """Format data for output."""
         return f"Formatted: {data}"
-    __cribo_module.format_output = format_output
+    _cribo_module.format_output = format_output
     InputData = typing.Dict[str, typing.Any]
-    __cribo_module.InputData = InputData
+    _cribo_module.InputData = InputData
     FormattedOutput = typing.Union[str, typing.Dict[str, typing.Any]]
-    __cribo_module.FormattedOutput = FormattedOutput
-    return __cribo_module
+    _cribo_module.FormattedOutput = FormattedOutput
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_41d36f_mypackage_core():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.core'
+def _cribo_init___cribo_41d36f_mypackage_core():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.core'
     Dict = typing.Dict
-    __cribo_module.Dict = Dict
+    _cribo_module.Dict = Dict
     List = typing.List
-    __cribo_module.List = List
+    _cribo_module.List = List
     Any = typing.Any
-    __cribo_module.Any = Any
+    _cribo_module.Any = Any
 
     def process_data(data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
         """Process input data and return results.\n\n    This function uses forward references in type hints.\n    """
         result: ProcessingResult = {"input": data, "processed": True, "output": _transform_data(data)}
         return result
-    __cribo_module.process_data = process_data
+    _cribo_module.process_data = process_data
 
     def _transform_data(data: typing.Dict[str, typing.Any]) -> typing.List[str]:
         """Transform data into list format."""
         return [f"{k}={v}" for k, v in data.items()]
-    __cribo_module._transform_data = _transform_data
+    _cribo_module._transform_data = _transform_data
     ProcessingResult = typing.Dict[str, typing.Any]
-    __cribo_module.ProcessingResult = ProcessingResult
-    return __cribo_module
-mypackage.core = __cribo_init___cribo_41d36f_mypackage_core()
+    _cribo_module.ProcessingResult = ProcessingResult
+    return _cribo_module
+mypackage.core = _cribo_init___cribo_41d36f_mypackage_core()
 process_data = mypackage.core.process_data
-mypackage.submodule.utils = __cribo_init___cribo_c3d681_mypackage_submodule_utils()
+mypackage.submodule.utils = _cribo_init___cribo_c3d681_mypackage_submodule_utils()
 validate_input = mypackage.submodule.utils.validate_input
 def main() -> None:
     """Main function with type annotations that require future import."""

--- a/crates/cribo/tests/snapshots/bundled_code@importlib_deduplication.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@importlib_deduplication.snap
@@ -10,49 +10,49 @@ import functools
 import types
 package = types.SimpleNamespace(__name__='package')
 @functools.cache
-def __cribo_init___cribo_75ebb7_package_submodule():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'package.submodule'
+def _cribo_init___cribo_75ebb7_package_submodule():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'package.submodule'
     print("package/submodule.py is being executed!")
     sub_counter = 10
-    __cribo_module.sub_counter = sub_counter
-    return __cribo_module
+    _cribo_module.sub_counter = sub_counter
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_20ca72_package():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'package'
+def _cribo_init___cribo_20ca72_package():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'package'
     print("package/__init__.py is being executed!")
-    return __cribo_module
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_26ef78_mymodule():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mymodule'
+def _cribo_init___cribo_26ef78_mymodule():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mymodule'
     print("mymodule.py is being executed!")
     counter = 1
-    __cribo_module.counter = counter
+    _cribo_module.counter = counter
     test_value = "Original"
-    __cribo_module.test_value = test_value
-    return __cribo_module
+    _cribo_module.test_value = test_value
+    return _cribo_module
 """Test how importlib.import_module handles sys.modules and deduplication"""
 print("=== Testing importlib.import_module deduplication ===\n")
-mymodule = __cribo_init___cribo_26ef78_mymodule()
-mymodule2 = __cribo_init___cribo_26ef78_mymodule()
+mymodule = _cribo_init___cribo_26ef78_mymodule()
+mymodule2 = _cribo_init___cribo_26ef78_mymodule()
 print(f"   Are they the same object? {mymodule is mymodule2}")
-__cribo_init_result = __cribo_init___cribo_20ca72_package()
+__cribo_init_result = _cribo_init___cribo_20ca72_package()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(package, attr, getattr(__cribo_init_result, attr))
-package.submodule = __cribo_init___cribo_75ebb7_package_submodule()
+package.submodule = _cribo_init___cribo_75ebb7_package_submodule()
 submodule = package.submodule
-submodule2 = __cribo_init___cribo_75ebb7_package_submodule()
+submodule2 = _cribo_init___cribo_75ebb7_package_submodule()
 print(f"   Are they the same object? {submodule is submodule2}")
-submodule3 = __cribo_init___cribo_75ebb7_package_submodule()
+submodule3 = _cribo_init___cribo_75ebb7_package_submodule()
 print(f"   Are they the same object? {submodule is submodule3}")
 print("\n=== Testing modification propagation ===")
 mymodule.test_value = "Modified!"
 print(f"Set mymodule.test_value = 'Modified!'")
 print(f"mymodule2.test_value = {mymodule2.test_value}")
-mymodule_new = __cribo_init___cribo_26ef78_mymodule()
+mymodule_new = _cribo_init___cribo_26ef78_mymodule()
 print(f"After reimport mymodule_new.counter = {mymodule_new.counter}")
 print(f"Are they the same object? {mymodule is mymodule_new}")
 print(f"Original mymodule still has counter = {mymodule.counter}")

--- a/crates/cribo/tests/snapshots/bundled_code@importlib_edge_cases.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@importlib_edge_cases.snap
@@ -9,17 +9,17 @@ input_file: crates/cribo/tests/fixtures/importlib_edge_cases/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_332fbf_my_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my-module'
+def _cribo_init___cribo_332fbf_my_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my-module'
     value = 42
-    __cribo_module.value = value
+    _cribo_module.value = value
 
     def get_value():
-        return __cribo_module.value
-    __cribo_module.get_value = get_value
-    return __cribo_module
-mod = __cribo_init___cribo_332fbf_my_module()
+        return _cribo_module.value
+    _cribo_module.get_value = get_value
+    return _cribo_module
+mod = _cribo_init___cribo_332fbf_my_module()
 print(f"Value: {mod.value}")
 print(f"Function result: {mod.get_value()}")
 assert mod.value == 42

--- a/crates/cribo/tests/snapshots/bundled_code@importlib_static.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@importlib_static.snap
@@ -9,9 +9,9 @@ input_file: crates/cribo/tests/fixtures/importlib_static/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_5687a6__2024_config():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = '2024-config'
+def _cribo_init___cribo_5687a6__2024_config():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = '2024-config'
     """Module starting with a number - can't be imported with regular import."""
 
     class Config2024:
@@ -23,20 +23,20 @@ def __cribo_init___cribo_5687a6__2024_config():
         def get_config(cls):
             return {"year": cls.YEAR, "version": cls.VERSION, "features": cls.FEATURES}
     Config2024.__module__ = '2024-config'
-    __cribo_module.Config2024 = Config2024
+    _cribo_module.Config2024 = Config2024
 
     def load_yearly_config():
         return Config2024()
-    __cribo_module.load_yearly_config = load_yearly_config
+    _cribo_module.load_yearly_config = load_yearly_config
     SUPPORTED_YEARS = [2022, 2023, 2024]
-    __cribo_module.SUPPORTED_YEARS = SUPPORTED_YEARS
+    _cribo_module.SUPPORTED_YEARS = SUPPORTED_YEARS
     CONFIG_PREFIX = "config-"
-    __cribo_module.CONFIG_PREFIX = CONFIG_PREFIX
-    return __cribo_module
+    _cribo_module.CONFIG_PREFIX = CONFIG_PREFIX
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_ec6681_for_():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'for'
+def _cribo_init___cribo_ec6681_for_():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'for'
     """Module named 'for' - a Python keyword for loops."""
 
     class ForLoop:
@@ -51,20 +51,20 @@ def __cribo_init___cribo_ec6681_for_():
                 results.append(f"Processing: {item}")
             return results
     ForLoop.__module__ = 'for'
-    __cribo_module.ForLoop = ForLoop
+    _cribo_module.ForLoop = ForLoop
 
     def create_loop(items):
         return ForLoop(items)
-    __cribo_module.create_loop = create_loop
+    _cribo_module.create_loop = create_loop
     LOOP_TYPES = ["for", "while", "comprehension"]
-    __cribo_module.LOOP_TYPES = LOOP_TYPES
+    _cribo_module.LOOP_TYPES = LOOP_TYPES
     MAX_ITERATIONS = 1000
-    __cribo_module.MAX_ITERATIONS = MAX_ITERATIONS
-    return __cribo_module
+    _cribo_module.MAX_ITERATIONS = MAX_ITERATIONS
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_944eb6_def_():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'def'
+def _cribo_init___cribo_944eb6_def_():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'def'
     """Module named 'def' - another Python keyword."""
 
     class FunctionDefinition:
@@ -77,20 +77,20 @@ def __cribo_init___cribo_944eb6_def_():
             params_str = ", ".join(self.params)
             return f"def {self.name}({params_str})"
     FunctionDefinition.__module__ = 'def'
-    __cribo_module.FunctionDefinition = FunctionDefinition
+    _cribo_module.FunctionDefinition = FunctionDefinition
 
     def define_function(name, *args):
         return FunctionDefinition(name, list(args))
-    __cribo_module.define_function = define_function
+    _cribo_module.define_function = define_function
     BUILTIN_FUNCTIONS = ["print", "len", "range", "sorted"]
-    __cribo_module.BUILTIN_FUNCTIONS = BUILTIN_FUNCTIONS
+    _cribo_module.BUILTIN_FUNCTIONS = BUILTIN_FUNCTIONS
     DEFINITION_TEMPLATE = "def {}(): pass"
-    __cribo_module.DEFINITION_TEMPLATE = DEFINITION_TEMPLATE
-    return __cribo_module
+    _cribo_module.DEFINITION_TEMPLATE = DEFINITION_TEMPLATE
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_004e55_class_():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'class'
+def _cribo_init___cribo_004e55_class_():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'class'
     """Module named 'class' - a Python keyword that can't be used in import statements."""
 
     class MetaClass:
@@ -102,20 +102,20 @@ def __cribo_init___cribo_004e55_class_():
         def describe(self):
             return f"This is a {self.type} named {self.name}"
     MetaClass.__module__ = 'class'
-    __cribo_module.MetaClass = MetaClass
+    _cribo_module.MetaClass = MetaClass
 
     def create_class_instance(class_name):
         return MetaClass(class_name)
-    __cribo_module.create_class_instance = create_class_instance
+    _cribo_module.create_class_instance = create_class_instance
     CLASS_TYPES = ["abstract", "concrete", "meta"]
-    __cribo_module.CLASS_TYPES = CLASS_TYPES
+    _cribo_module.CLASS_TYPES = CLASS_TYPES
     DEFAULT_CLASS_NAME = "KeywordModule"
-    __cribo_module.DEFAULT_CLASS_NAME = DEFAULT_CLASS_NAME
-    return __cribo_module
+    _cribo_module.DEFAULT_CLASS_NAME = DEFAULT_CLASS_NAME
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_64c186_api_client():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'api-client'
+def _cribo_init___cribo_64c186_api_client():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'api-client'
     """Another module with hyphen - demonstrating API client functionality."""
 
     class APIClient:
@@ -127,20 +127,20 @@ def __cribo_init___cribo_64c186_api_client():
         def make_request(self, endpoint):
             return f"Making request to {self.base_url}/{endpoint}"
     APIClient.__module__ = 'api-client'
-    __cribo_module.APIClient = APIClient
+    _cribo_module.APIClient = APIClient
 
     def create_client(url=None):
         return APIClient(url) if url else APIClient()
-    __cribo_module.create_client = create_client
+    _cribo_module.create_client = create_client
     API_VERSION = "2.0-stable"
-    __cribo_module.API_VERSION = API_VERSION
+    _cribo_module.API_VERSION = API_VERSION
     SUPPORTED_ENDPOINTS = ["users", "posts", "comments"]
-    __cribo_module.SUPPORTED_ENDPOINTS = SUPPORTED_ENDPOINTS
-    return __cribo_module
+    _cribo_module.SUPPORTED_ENDPOINTS = SUPPORTED_ENDPOINTS
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_d8297b_data_processor():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'data-processor'
+def _cribo_init___cribo_d8297b_data_processor():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'data-processor'
     """Module with hyphen in name - can't be imported with regular import statement."""
 
     class DataProcessor:
@@ -151,21 +151,21 @@ def __cribo_init___cribo_d8297b_data_processor():
         def process(self, data):
             return f"Processing {data} with hyphenated module"
     DataProcessor.__module__ = 'data-processor'
-    __cribo_module.DataProcessor = DataProcessor
+    _cribo_module.DataProcessor = DataProcessor
 
     def get_processor_info():
         return "This is a data processor from a module with a hyphen"
-    __cribo_module.get_processor_info = get_processor_info
+    _cribo_module.get_processor_info = get_processor_info
     PROCESSOR_VERSION = "1.0-hyphenated"
-    __cribo_module.PROCESSOR_VERSION = PROCESSOR_VERSION
-    return __cribo_module
+    _cribo_module.PROCESSOR_VERSION = PROCESSOR_VERSION
+    return _cribo_module
 """Main module demonstrating importlib usage with static string literals."""
-data_processor = __cribo_init___cribo_d8297b_data_processor()
-api_client = __cribo_init___cribo_64c186_api_client()
-class_module = __cribo_init___cribo_004e55_class_()
-def_module = __cribo_init___cribo_944eb6_def_()
-for_module = __cribo_init___cribo_ec6681_for_()
-config_2024 = __cribo_init___cribo_5687a6__2024_config()
+data_processor = _cribo_init___cribo_d8297b_data_processor()
+api_client = _cribo_init___cribo_64c186_api_client()
+class_module = _cribo_init___cribo_004e55_class_()
+def_module = _cribo_init___cribo_944eb6_def_()
+for_module = _cribo_init___cribo_ec6681_for_()
+config_2024 = _cribo_init___cribo_5687a6__2024_config()
 def main():
     processor = data_processor.DataProcessor()
     print(f"Processor: {processor.name}")

--- a/crates/cribo/tests/snapshots/bundled_code@init_reexports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@init_reexports.snap
@@ -38,9 +38,9 @@ mypackage_utils.constants = mypackage_utils_constants
 mypackage_utils_helper = types.SimpleNamespace(__name__='mypackage.utils.helper')
 mypackage_utils.helper = mypackage_utils_helper
 @functools.cache
-def __cribo_init___cribo_de6c46_mypackage_config():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.config'
+def _cribo_init___cribo_de6c46_mypackage_config():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.config'
     """Configuration module."""
 
     class Config:
@@ -50,31 +50,31 @@ def __cribo_init___cribo_de6c46_mypackage_config():
             self.DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
             self.LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
     Config.__module__ = 'mypackage.config'
-    __cribo_module.Config = Config
+    _cribo_module.Config = Config
     config = Config()
-    __cribo_module.config = config
-    return __cribo_module
+    _cribo_module.config = config
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_a81151_mypackage():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage'
+def _cribo_init___cribo_a81151_mypackage():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage'
     """\nPackage initialization with re-exports.\n\nThis __init__.py demonstrates the pattern where imports are made but not directly used\nwithin this file - they are re-exports for the package interface.\nThese imports should NOT be stripped as unused, even though they don't appear\nto be used within this file itself.\n"""
-    __cribo_module.process_data = process_data
-    __cribo_module.format_data = format_data
-    mypackage.config = __cribo_init___cribo_de6c46_mypackage_config()
+    _cribo_module.process_data = process_data
+    _cribo_module.format_data = format_data
+    mypackage.config = _cribo_init___cribo_de6c46_mypackage_config()
     config = mypackage.config.config
-    __cribo_module.config = config
-    __cribo_module.helper_function = helper_function
+    _cribo_module.config = config
+    _cribo_module.helper_function = helper_function
     __version__ = "1.0.0"
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
     DEBUG_MODE = config.DEBUG
-    __cribo_module.DEBUG_MODE = DEBUG_MODE
-    __cribo_module.utils = mypackage_utils
-    __cribo_module.formatter = mypackage_formatter
-    __cribo_module.data_processor = mypackage_data_processor
-    return __cribo_module
-mypackage.config = __cribo_init___cribo_de6c46_mypackage_config()
-__cribo_init_result = __cribo_init___cribo_a81151_mypackage()
+    _cribo_module.DEBUG_MODE = DEBUG_MODE
+    _cribo_module.utils = mypackage_utils
+    _cribo_module.formatter = mypackage_formatter
+    _cribo_module.data_processor = mypackage_data_processor
+    return _cribo_module
+mypackage.config = _cribo_init___cribo_de6c46_mypackage_config()
+__cribo_init_result = _cribo_init___cribo_a81151_mypackage()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(mypackage, attr, getattr(__cribo_init_result, attr))
@@ -82,7 +82,7 @@ mypackage_utils_helper.helper_function = helper_function
 mypackage_formatter.format_data = format_data
 mypackage_data_processor.process_data = process_data
 '''\nTest script demonstrating __init__.py re-export preservation.\n\nThis fixture tests that imports in __init__.py files are preserved even if they\nappear "unused" within that file, as they are typically re-exports for the package interface.\n'''
-__cribo_init_result = __cribo_init___cribo_a81151_mypackage()
+__cribo_init_result = _cribo_init___cribo_a81151_mypackage()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(mypackage, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_collision.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_collision.snap
@@ -13,13 +13,13 @@ pkg_submodule = types.SimpleNamespace(__name__='pkg.submodule')
 pkg.submodule = pkg_submodule
 def create_object():
     """Factory function that imports from parent."""
-    pkg = __cribo_init___cribo_9c0ae3_pkg()
+    pkg = _cribo_init___cribo_9c0ae3_pkg()
     return pkg.MyObject()
 @functools.cache
-def __cribo_init___cribo_9c0ae3_pkg():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg'
-    __cribo_module.create_object = create_object
+def _cribo_init___cribo_9c0ae3_pkg():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg'
+    _cribo_module.create_object = create_object
 
     class MyMetaclass(type):
         """The metaclass."""
@@ -29,7 +29,7 @@ def __cribo_init___cribo_9c0ae3_pkg():
             if hasattr(cls, "tag"):
                 print(f"Metaclass initialized {name} with tag {cls.tag}")
     MyMetaclass.__module__ = 'pkg'
-    __cribo_module.MyMetaclass = MyMetaclass
+    _cribo_module.MyMetaclass = MyMetaclass
 
     class MyObject(metaclass=MyMetaclass):
         """An object with metaclass."""
@@ -41,11 +41,11 @@ def __cribo_init___cribo_9c0ae3_pkg():
         def __repr__(self):
             return f"MyObject(value={self.value})"
     MyObject.__module__ = 'pkg'
-    __cribo_module.MyObject = MyObject
-    __cribo_module.submodule = pkg_submodule
-    return __cribo_module
+    _cribo_module.MyObject = MyObject
+    _cribo_module.submodule = pkg_submodule
+    return _cribo_module
 pkg_submodule.create_object = create_object
-pkg = __cribo_init___cribo_9c0ae3_pkg()
+pkg = _cribo_init___cribo_9c0ae3_pkg()
 MyObject = pkg.MyObject
 create_object = create_object
 obj = create_object()

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_init.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_init.snap
@@ -10,10 +10,10 @@ import functools
 import types
 yaml_pkg = types.SimpleNamespace(__name__='yaml_pkg')
 @functools.cache
-def __cribo_init___cribo_8a246b_yaml_pkg_base():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_pkg.base'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+def _cribo_init___cribo_8a246b_yaml_pkg_base():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_pkg.base'
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """An object with a metaclass"""
@@ -22,8 +22,8 @@ def __cribo_init___cribo_8a246b_yaml_pkg_base():
         def __str__(self):
             return f"YAMLObject(tag={self.yaml_tag})"
     YAMLObject.__module__ = 'yaml_pkg.base'
-    __cribo_module.YAMLObject = YAMLObject
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    return _cribo_module
 class YAMLObjectMetaclass(type):
     """Metaclass that adds yaml_tag"""
 
@@ -34,7 +34,7 @@ class YAMLObjectMetaclass(type):
 YAMLObjectMetaclass.__module__ = 'yaml_pkg.meta'
 yaml_pkg_meta = types.SimpleNamespace(__name__='yaml_pkg.meta')
 yaml_pkg.meta = yaml_pkg_meta
-yaml_pkg.base = __cribo_init___cribo_8a246b_yaml_pkg_base()
+yaml_pkg.base = _cribo_init___cribo_8a246b_yaml_pkg_base()
 yaml_pkg_meta.YAMLObjectMetaclass = YAMLObjectMetaclass
 yaml_pkg.YAMLObject = yaml_pkg.base.YAMLObject
 obj = yaml_pkg.YAMLObject()

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_init_alias.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_init_alias.snap
@@ -10,10 +10,10 @@ import functools
 import types
 yaml_pkg = types.SimpleNamespace(__name__='yaml_pkg')
 @functools.cache
-def __cribo_init___cribo_6d74f2_yaml_pkg_base():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_pkg.base'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+def _cribo_init___cribo_6d74f2_yaml_pkg_base():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_pkg.base'
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """An object with a metaclass"""
@@ -22,8 +22,8 @@ def __cribo_init___cribo_6d74f2_yaml_pkg_base():
         def __str__(self):
             return f"YAMLObject(tag={self.yaml_tag})"
     YAMLObject.__module__ = 'yaml_pkg.base'
-    __cribo_module.YAMLObject = YAMLObject
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    return _cribo_module
 class YAMLObjectMetaclass(type):
     """Metaclass that adds yaml_tag"""
 
@@ -34,7 +34,7 @@ class YAMLObjectMetaclass(type):
 YAMLObjectMetaclass.__module__ = 'yaml_pkg.meta'
 yaml_pkg_meta = types.SimpleNamespace(__name__='yaml_pkg.meta')
 yaml_pkg.meta = yaml_pkg_meta
-yaml_pkg.base = __cribo_init___cribo_6d74f2_yaml_pkg_base()
+yaml_pkg.base = _cribo_init___cribo_6d74f2_yaml_pkg_base()
 yaml_pkg_meta.YAMLObjectMetaclass = YAMLObjectMetaclass
 yaml_pkg.YO = yaml_pkg.base.YAMLObject
 obj = yaml_pkg.YO()

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_renamed.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_renamed.snap
@@ -24,36 +24,36 @@ class Dumper:
 Loader.__module__ = 'yaml_module.loader'
 Dumper.__module__ = 'yaml_module.loader'
 @functools.cache
-def __cribo_init___cribo_1fd8cb_yaml_module_other():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_module.other'
+def _cribo_init___cribo_1fd8cb_yaml_module_other():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_module.other'
 
     class YAMLObjectMetaclass(type):
         """First version of the metaclass"""
         pass
     YAMLObjectMetaclass.__module__ = 'yaml_module.other'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """First version of YAMLObject"""
         source = "other"
     YAMLObject.__module__ = 'yaml_module.other'
-    __cribo_module.YAMLObject = YAMLObject
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_1309dd_yaml_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_module'
+def _cribo_init___cribo_1309dd_yaml_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_module'
     global Dumper, Loader
-    __cribo_module.Dumper = Dumper
-    __cribo_module.Loader = Loader
+    _cribo_module.Dumper = Dumper
+    _cribo_module.Loader = Loader
     """\nModule that mimics PyYAML's pattern where:\n1. It uses wildcard imports\n2. It defines YAMLObjectMetaclass and YAMLObject (causing collisions with other.py)\n3. YAMLObject references symbols from wildcard imports in its class body\n4. When bundled, the renamed class still references the original metaclass name\n"""
-    yaml_module.other = __cribo_init___cribo_1fd8cb_yaml_module_other()
+    yaml_module.other = _cribo_init___cribo_1fd8cb_yaml_module_other()
     OtherYAMLObject = yaml_module.other.YAMLObject
-    __cribo_module.OtherYAMLObject = OtherYAMLObject
-    yaml_module.other = __cribo_init___cribo_1fd8cb_yaml_module_other()
+    _cribo_module.OtherYAMLObject = OtherYAMLObject
+    yaml_module.other = _cribo_init___cribo_1fd8cb_yaml_module_other()
     OtherYAMLObjectMetaclass = yaml_module.other.YAMLObjectMetaclass
-    __cribo_module.OtherYAMLObjectMetaclass = OtherYAMLObjectMetaclass
+    _cribo_module.OtherYAMLObjectMetaclass = OtherYAMLObjectMetaclass
 
     class YAMLObjectMetaclass(type):
         """The metaclass for YAMLObject"""
@@ -64,7 +64,7 @@ def __cribo_init___cribo_1309dd_yaml_module():
                 cls.yaml_loader.add_constructor(cls.yaml_tag, cls.from_yaml)
                 cls.yaml_dumper.add_representer(cls, cls.to_yaml)
     YAMLObjectMetaclass.__module__ = 'yaml_module'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """\n    YAMLObject that references wildcard-imported symbols in class body.\n    When bundled and renamed, this will become something like:\n    class YAMLObject_1(metaclass=YAMLObjectMetaclass):\n    But YAMLObjectMetaclass won't exist - only YAMLObjectMetaclass_1 will.\n    """
@@ -81,13 +81,13 @@ def __cribo_init___cribo_1309dd_yaml_module():
         def to_yaml(cls, dumper, data):
             return f"Dumping {cls.__name__}"
     YAMLObject.__module__ = 'yaml_module'
-    __cribo_module.YAMLObject = YAMLObject
-    __cribo_module.loader = yaml_module_loader
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    _cribo_module.loader = yaml_module_loader
+    return _cribo_module
 yaml_module_loader.Loader = Loader
 yaml_module_loader.Dumper = Dumper
 """\nTest case that reproduces the PyYAML metaclass renaming bug.\n\nExpected behavior: The bundled code should work correctly.\nActual behavior: NameError because renamed class references original metaclass name.\n"""
-__cribo_init_result = __cribo_init___cribo_1309dd_yaml_module()
+__cribo_init_result = _cribo_init___cribo_1309dd_yaml_module()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(yaml_module, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_wildcard.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_forward_ref_wildcard.snap
@@ -10,10 +10,10 @@ import functools
 import types
 wildcard_pkg = types.SimpleNamespace(__name__='wildcard_pkg')
 @functools.cache
-def __cribo_init___cribo_5d409b_wildcard_pkg_base():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'wildcard_pkg.base'
-    __cribo_module.WildcardMetaclass = WildcardMetaclass
+def _cribo_init___cribo_5d409b_wildcard_pkg_base():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'wildcard_pkg.base'
+    _cribo_module.WildcardMetaclass = WildcardMetaclass
 
     class WildcardObject(metaclass=WildcardMetaclass):
         """An object with a metaclass"""
@@ -22,8 +22,8 @@ def __cribo_init___cribo_5d409b_wildcard_pkg_base():
         def __str__(self):
             return f"WildcardObject(tag={self.yaml_tag})"
     WildcardObject.__module__ = 'wildcard_pkg.base'
-    __cribo_module.WildcardObject = WildcardObject
-    return __cribo_module
+    _cribo_module.WildcardObject = WildcardObject
+    return _cribo_module
 class WildcardMetaclass(type):
     """Metaclass that adds yaml_tag"""
 
@@ -34,7 +34,7 @@ class WildcardMetaclass(type):
 WildcardMetaclass.__module__ = 'wildcard_pkg.meta'
 wildcard_pkg_meta = types.SimpleNamespace(__name__='wildcard_pkg.meta')
 wildcard_pkg.meta = wildcard_pkg_meta
-wildcard_pkg.base = __cribo_init___cribo_5d409b_wildcard_pkg_base()
+wildcard_pkg.base = _cribo_init___cribo_5d409b_wildcard_pkg_base()
 WildcardObject = wildcard_pkg.base.WildcardObject
 WildcardMetaclass = wildcard_pkg.base.WildcardMetaclass
 wildcard_pkg_meta.WildcardMetaclass = WildcardMetaclass

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_ordering_collision.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_ordering_collision.snap
@@ -9,9 +9,9 @@ input_file: crates/cribo/tests/fixtures/metaclass_ordering_collision/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_276673_module_b():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'module_b'
+def _cribo_init___cribo_276673_module_b():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'module_b'
     """Second module with same-named metaclass and class - will get renamed."""
 
     class YAMLObjectMetaclass(type):
@@ -22,7 +22,7 @@ def __cribo_init___cribo_276673_module_b():
             if "yaml_tag" in kwds and kwds["yaml_tag"] is not None:
                 cls._registered_b = True
     YAMLObjectMetaclass.__module__ = 'module_b'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """Another class with the same name but different metaclass."""
@@ -31,12 +31,12 @@ def __cribo_init___cribo_276673_module_b():
         def __init__(self):
             pass
     YAMLObject.__module__ = 'module_b'
-    __cribo_module.YAMLObject = YAMLObject
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_12d4a8_module_a():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'module_a'
+def _cribo_init___cribo_12d4a8_module_a():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'module_a'
     """First module with metaclass and class - will have original names."""
 
     class YAMLObjectMetaclass(type):
@@ -47,7 +47,7 @@ def __cribo_init___cribo_12d4a8_module_a():
             if "yaml_tag" in kwds and kwds["yaml_tag"] is not None:
                 cls._registered_a = True
     YAMLObjectMetaclass.__module__ = 'module_a'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """An object with metaclass from module_a."""
@@ -56,12 +56,12 @@ def __cribo_init___cribo_12d4a8_module_a():
         def __init__(self):
             pass
     YAMLObject.__module__ = 'module_a'
-    __cribo_module.YAMLObject = YAMLObject
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    return _cribo_module
 """Test that demonstrates metaclass ordering issue with name collisions."""
-module_a = __cribo_init___cribo_12d4a8_module_a()
+module_a = _cribo_init___cribo_12d4a8_module_a()
 YAMLObject = module_a.YAMLObject
-module_b = __cribo_init___cribo_276673_module_b()
+module_b = _cribo_init___cribo_276673_module_b()
 YAMLObjectB = module_b.YAMLObject
 def test_both_classes():
     """Test that both metaclass-based classes work."""

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_renamed_forward_ref.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_renamed_forward_ref.snap
@@ -9,9 +9,9 @@ input_file: crates/cribo/tests/fixtures/metaclass_renamed_forward_ref/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_c0fc3d_other():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'other'
+def _cribo_init___cribo_c0fc3d_other():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'other'
     """Another module with similar class names to trigger renaming."""
 
     class MyMetaclass(type):
@@ -21,7 +21,7 @@ def __cribo_init___cribo_c0fc3d_other():
             super(MyMetaclass, cls).__init__(name, bases, kwds)
             cls.other_attr = "from other"
     MyMetaclass.__module__ = 'other'
-    __cribo_module.MyMetaclass = MyMetaclass
+    _cribo_module.MyMetaclass = MyMetaclass
 
     class MyObject(metaclass=MyMetaclass):
         """Another class with the same name."""
@@ -29,12 +29,12 @@ def __cribo_init___cribo_c0fc3d_other():
         def __repr__(self):
             return f"OtherMyObject(other_attr={self.other_attr})"
     MyObject.__module__ = 'other'
-    __cribo_module.MyObject = MyObject
-    return __cribo_module
+    _cribo_module.MyObject = MyObject
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_a6386c_base():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'base'
+def _cribo_init___cribo_a6386c_base():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'base'
     """Base module with metaclass definitions."""
 
     class MyMetaclass(type):
@@ -44,7 +44,7 @@ def __cribo_init___cribo_a6386c_base():
             super(MyMetaclass, cls).__init__(name, bases, kwds)
             cls.base_attr = "from base"
     MyMetaclass.__module__ = 'base'
-    __cribo_module.MyMetaclass = MyMetaclass
+    _cribo_module.MyMetaclass = MyMetaclass
 
     class MyObject(metaclass=MyMetaclass):
         """A class using the metaclass."""
@@ -52,13 +52,13 @@ def __cribo_init___cribo_a6386c_base():
         def __repr__(self):
             return f"MyObject(base_attr={self.base_attr})"
     MyObject.__module__ = 'base'
-    __cribo_module.MyObject = MyObject
-    return __cribo_module
+    _cribo_module.MyObject = MyObject
+    return _cribo_module
 """\nTest fixture for metaclass forward reference with renaming issue.\n\nThis reproduces the bug where class renaming causes forward references\nto metaclasses, similar to what happens with PyYAML.\n"""
-base = __cribo_init___cribo_a6386c_base()
+base = _cribo_init___cribo_a6386c_base()
 MyMetaclass = base.MyMetaclass
 MyObject = base.MyObject
-other = __cribo_init___cribo_c0fc3d_other()
+other = _cribo_init___cribo_c0fc3d_other()
 OtherMeta = other.MyMetaclass
 OtherObject = other.MyObject
 obj1 = MyObject()

--- a/crates/cribo/tests/snapshots/bundled_code@metaclass_with_wildcard_imports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@metaclass_with_wildcard_imports.snap
@@ -48,14 +48,14 @@ BaseLoader.__module__ = 'yaml_pkg.loader'
 Loader.__module__ = 'yaml_pkg.loader'
 FullLoader.__module__ = 'yaml_pkg.loader'
 @functools.cache
-def __cribo_init___cribo_5b2acd_yaml_pkg():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_pkg'
+def _cribo_init___cribo_5b2acd_yaml_pkg():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_pkg'
     global BaseLoader, Dumper, FullLoader, Loader
-    __cribo_module.BaseLoader = BaseLoader
-    __cribo_module.Dumper = Dumper
-    __cribo_module.FullLoader = FullLoader
-    __cribo_module.Loader = Loader
+    _cribo_module.BaseLoader = BaseLoader
+    _cribo_module.Dumper = Dumper
+    _cribo_module.FullLoader = FullLoader
+    _cribo_module.Loader = Loader
 
     class YAMLObjectMetaclass(type):
         """\n    The metaclass for YAMLObject.\n    """
@@ -69,7 +69,7 @@ def __cribo_init___cribo_5b2acd_yaml_pkg():
                 else:
                     print(f"Registering {name} with {cls.yaml_loader.__name__}")
     YAMLObjectMetaclass.__module__ = 'yaml_pkg'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """\n    An object that uses a metaclass and references classes from wildcard imports.\n    This mimics PyYAML's structure.\n    """
@@ -86,16 +86,16 @@ def __cribo_init___cribo_5b2acd_yaml_pkg():
         def to_yaml(cls, dumper, data):
             return f"Dumping {cls.__name__} to YAML"
     YAMLObject.__module__ = 'yaml_pkg'
-    __cribo_module.YAMLObject = YAMLObject
-    __cribo_module.dumper = yaml_pkg_dumper
-    __cribo_module.loader = yaml_pkg_loader
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    _cribo_module.dumper = yaml_pkg_dumper
+    _cribo_module.loader = yaml_pkg_loader
+    return _cribo_module
 yaml_pkg_dumper.Dumper = Dumper
 yaml_pkg_loader.BaseLoader = BaseLoader
 yaml_pkg_loader.Loader = Loader
 yaml_pkg_loader.FullLoader = FullLoader
 """\nTest case for metaclass forward reference issue with wildcard imports.\n\nThis reproduces the PyYAML bundling issue where:\n1. A class uses a metaclass that's defined later in the same module\n2. The class body references symbols imported via wildcard imports\n3. When bundled, the metaclass definition gets placed after its usage\n"""
-yaml_pkg = __cribo_init___cribo_5b2acd_yaml_pkg()
+yaml_pkg = _cribo_init___cribo_5b2acd_yaml_pkg()
 print("Module loaded successfully")
 print(f"YAMLObject name: {yaml_pkg.YAMLObject.__name__}")
 print(f"YAMLObjectMetaclass name: {yaml_pkg.YAMLObjectMetaclass.__name__}")

--- a/crates/cribo/tests/snapshots/bundled_code@module_first_resolution.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@module_first_resolution.snap
@@ -9,15 +9,15 @@ input_file: crates/cribo/tests/fixtures/module_first_resolution/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_e25798_foo():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'foo'
+def _cribo_init___cribo_e25798_foo():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'foo'
     source = "foo/__init__.py (package)"
-    __cribo_module.source = source
+    _cribo_module.source = source
     value = "CORRECT - package"
-    __cribo_module.value = value
+    _cribo_module.value = value
     print("Successfully imported foo package")
-    return __cribo_module
-foo = __cribo_init___cribo_e25798_foo()
+    return _cribo_module
+foo = _cribo_init___cribo_e25798_foo()
 print(f"Imported foo from: {foo.source}")
 print(f"foo.value = {foo.value}")

--- a/crates/cribo/tests/snapshots/bundled_code@module_setattr_with_circular_deps.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@module_setattr_with_circular_deps.snap
@@ -18,28 +18,28 @@ pkg._models = pkg__models
 pkg__types = types.SimpleNamespace(__name__='pkg._types')
 pkg._types = pkg__types
 @functools.cache
-def __cribo_init___cribo_1fb248_pkg():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg'
+def _cribo_init___cribo_1fb248_pkg():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg'
     global AsyncStream, SyncStream
-    __cribo_module.AsyncStream = AsyncStream
-    __cribo_module.SyncStream = SyncStream
+    _cribo_module.AsyncStream = AsyncStream
+    _cribo_module.SyncStream = SyncStream
     """Package that sets __module__ on all exported items, like httpx does."""
-    __cribo_module.Client = Client
-    __cribo_module.Request = Request
-    __cribo_module.Response = Response
-    __cribo_module.main = main
+    _cribo_module.Client = Client
+    _cribo_module.Request = Request
+    _cribo_module.Response = Response
+    _cribo_module.main = main
     __all__ = ["AsyncStream", "SyncStream", "Client", "Request", "Response", "main"]
-    __locals = vars(__cribo_module)
-    __cribo_module.__locals = __locals
+    __locals = vars(_cribo_module)
+    _cribo_module.__locals = __locals
     for __name in __all__:
         if not __name.startswith("__"):
             setattr(__locals[__name], "__module__", "pkg")
-    __cribo_module._main = pkg__main
-    __cribo_module._models = pkg__models
-    __cribo_module._client = pkg__client
-    __cribo_module._types = pkg__types
-    return __cribo_module
+    _cribo_module._main = pkg__main
+    _cribo_module._models = pkg__models
+    _cribo_module._client = pkg__client
+    _cribo_module._types = pkg__types
+    return _cribo_module
 class Request:
     """Request model."""
 
@@ -83,7 +83,7 @@ Client.__module__ = 'pkg._client'
 AsyncStream.__module__ = 'pkg._types'
 SyncStream.__module__ = 'pkg._types'
 """Types module with stream classes."""
-pkg = __cribo_init___cribo_1fb248_pkg()
+pkg = _cribo_init___cribo_1fb248_pkg()
 pkg__main.main = main
 pkg__models.Request = Request
 pkg__models.Response = Response
@@ -91,7 +91,7 @@ pkg__client.Client = Client
 pkg__types.AsyncStream = AsyncStream
 pkg__types.SyncStream = SyncStream
 """Test module attribute setting on wildcard imports with circular dependencies."""
-pkg = __cribo_init___cribo_1fb248_pkg()
+pkg = _cribo_init___cribo_1fb248_pkg()
 stream_a = pkg.AsyncStream()
 stream_s = pkg.SyncStream()
 print(f"AsyncStream: {stream_a.read()}")

--- a/crates/cribo/tests/snapshots/bundled_code@module_side_effects_circular_order.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@module_side_effects_circular_order.snap
@@ -15,50 +15,50 @@ my_package_mod_l = types.SimpleNamespace(__name__='my_package.mod_l')
 my_package.mod_l = my_package_mod_l
 C_CONSTANT = 21
 @functools.cache
-def __cribo_init___cribo_c04dc3_my_package():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my_package'
-    my_package.mod_a = __cribo_init___cribo_e90488_my_package_mod_a()
+def _cribo_init___cribo_c04dc3_my_package():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my_package'
+    my_package.mod_a = _cribo_init___cribo_e90488_my_package_mod_a()
     mod_a = my_package.mod_a
-    __cribo_module.mod_a = mod_a
+    _cribo_module.mod_a = mod_a
     TOP_LEVEL_VAL = mod_a.A_VALUE
-    __cribo_module.TOP_LEVEL_VAL = TOP_LEVEL_VAL
-    print(__cribo_module.TOP_LEVEL_VAL)
-    __cribo_module.mod_l = my_package_mod_l
-    __cribo_module.mod_c = my_package_mod_c
-    return __cribo_module
+    _cribo_module.TOP_LEVEL_VAL = TOP_LEVEL_VAL
+    print(_cribo_module.TOP_LEVEL_VAL)
+    _cribo_module.mod_l = my_package_mod_l
+    _cribo_module.mod_c = my_package_mod_c
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_e90488_my_package_mod_a():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my_package.mod_a'
-    my_package.mod_b = __cribo_init___cribo_d862bd_my_package_mod_b()
+def _cribo_init___cribo_e90488_my_package_mod_a():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my_package.mod_a'
+    my_package.mod_b = _cribo_init___cribo_d862bd_my_package_mod_b()
     mod_b = my_package.mod_b
-    __cribo_module.mod_b = mod_b
+    _cribo_module.mod_b = mod_b
     A_VALUE = f"A -> {mod_b.B_DERIVED_VALUE}"
-    __cribo_module.A_VALUE = A_VALUE
-    return __cribo_module
+    _cribo_module.A_VALUE = A_VALUE
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_d862bd_my_package_mod_b():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'my_package.mod_b'
+def _cribo_init___cribo_d862bd_my_package_mod_b():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'my_package.mod_b'
     mod_c = types.SimpleNamespace()
-    __cribo_module.mod_c = mod_c
+    _cribo_module.mod_c = mod_c
     mod_c.C_CONSTANT = C_CONSTANT
     B_DERIVED_VALUE = mod_c.C_CONSTANT * 2
-    __cribo_module.B_DERIVED_VALUE = B_DERIVED_VALUE
+    _cribo_module.B_DERIVED_VALUE = B_DERIVED_VALUE
 
     def get_b_value():
         return f"B using '{LEAF_VALUE}' and derived value '{B_DERIVED_VALUE}'"
-    __cribo_module.get_b_value = get_b_value
-    return __cribo_module
-my_package.mod_a = __cribo_init___cribo_e90488_my_package_mod_a()
-my_package.mod_b = __cribo_init___cribo_d862bd_my_package_mod_b()
-__cribo_init_result = __cribo_init___cribo_c04dc3_my_package()
+    _cribo_module.get_b_value = get_b_value
+    return _cribo_module
+my_package.mod_a = _cribo_init___cribo_e90488_my_package_mod_a()
+my_package.mod_b = _cribo_init___cribo_d862bd_my_package_mod_b()
+__cribo_init_result = _cribo_init___cribo_c04dc3_my_package()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(my_package, attr, getattr(__cribo_init_result, attr))
 my_package_mod_c.C_CONSTANT = C_CONSTANT
-__cribo_init_result = __cribo_init___cribo_c04dc3_my_package()
+__cribo_init_result = _cribo_init___cribo_c04dc3_my_package()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(my_package, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@namespace_attribute_reference.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@namespace_attribute_reference.snap
@@ -13,12 +13,12 @@ class MyError(Exception):
     """Base exception class"""
     pass
 @functools.cache
-def __cribo_init___cribo_19d82f_mypkg_compat():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypkg.compat'
+def _cribo_init___cribo_19d82f_mypkg_compat():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypkg.compat'
     try:
         from json import JSONDecodeError
-        __cribo_module.JSONDecodeError = JSONDecodeError
+        _cribo_module.JSONDecodeError = JSONDecodeError
     except ImportError:
 
         class JSONDecodeError(ValueError):
@@ -29,11 +29,11 @@ def __cribo_init___cribo_19d82f_mypkg_compat():
                 self.doc = doc
                 self.pos = pos
     bytes = __import__('builtins').bytes
-    __cribo_module.bytes = bytes
+    _cribo_module.bytes = bytes
     basestring = str
-    __cribo_module.basestring = basestring
-    return __cribo_module
-mypkg.compat = __cribo_init___cribo_19d82f_mypkg_compat()
+    _cribo_module.basestring = basestring
+    return _cribo_module
+mypkg.compat = _cribo_init___cribo_19d82f_mypkg_compat()
 class MyJSONError(MyError, mypkg.compat.JSONDecodeError):
     """JSON error that inherits from compat JSONDecodeError"""
 
@@ -44,7 +44,7 @@ MyError.__module__ = 'mypkg.exceptions'
 MyJSONError.__module__ = 'mypkg.exceptions'
 mypkg_exceptions = types.SimpleNamespace(__name__='mypkg.exceptions')
 mypkg.exceptions = mypkg_exceptions
-mypkg.compat = __cribo_init___cribo_19d82f_mypkg_compat()
+mypkg.compat = _cribo_init___cribo_19d82f_mypkg_compat()
 exceptions = mypkg_exceptions
 mypkg_exceptions.MyError = MyError
 mypkg_exceptions.MyJSONError = MyJSONError

--- a/crates/cribo/tests/snapshots/bundled_code@private_module_vars.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@private_module_vars.snap
@@ -11,31 +11,31 @@ import re
 import types
 pkg = types.SimpleNamespace(__name__='pkg')
 @functools.cache
-def __cribo_init___cribo_73cafd_pkg__internal():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg._internal'
+def _cribo_init___cribo_73cafd_pkg__internal():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg._internal'
     """Internal module with private variables."""
     _VALID_HEADER_NAME_RE_BYTE = re.compile(rb"^[^:\s][^:\r\n]*$")
-    __cribo_module._VALID_HEADER_NAME_RE_BYTE = _VALID_HEADER_NAME_RE_BYTE
+    _cribo_module._VALID_HEADER_NAME_RE_BYTE = _VALID_HEADER_NAME_RE_BYTE
     _VALID_HEADER_NAME_RE_STR = re.compile(r"^[^:\s][^:\r\n]*$")
-    __cribo_module._VALID_HEADER_NAME_RE_STR = _VALID_HEADER_NAME_RE_STR
+    _cribo_module._VALID_HEADER_NAME_RE_STR = _VALID_HEADER_NAME_RE_STR
     _VALID_HEADER_VALUE_RE_BYTE = re.compile(rb"^\S[^\r\n]*$|^$")
-    __cribo_module._VALID_HEADER_VALUE_RE_BYTE = _VALID_HEADER_VALUE_RE_BYTE
+    _cribo_module._VALID_HEADER_VALUE_RE_BYTE = _VALID_HEADER_VALUE_RE_BYTE
     _VALID_HEADER_VALUE_RE_STR = re.compile(r"^\S[^\r\n]*$|^$")
-    __cribo_module._VALID_HEADER_VALUE_RE_STR = _VALID_HEADER_VALUE_RE_STR
+    _cribo_module._VALID_HEADER_VALUE_RE_STR = _VALID_HEADER_VALUE_RE_STR
     _HEADER_VALIDATORS_STR = _VALID_HEADER_NAME_RE_STR, _VALID_HEADER_VALUE_RE_STR
-    __cribo_module._HEADER_VALIDATORS_STR = _HEADER_VALIDATORS_STR
+    _cribo_module._HEADER_VALIDATORS_STR = _HEADER_VALIDATORS_STR
     _HEADER_VALIDATORS_BYTE = _VALID_HEADER_NAME_RE_BYTE, _VALID_HEADER_VALUE_RE_BYTE
-    __cribo_module._HEADER_VALIDATORS_BYTE = _HEADER_VALIDATORS_BYTE
+    _cribo_module._HEADER_VALIDATORS_BYTE = _HEADER_VALIDATORS_BYTE
     HEADER_VALIDATORS = {bytes: _HEADER_VALIDATORS_BYTE, str: _HEADER_VALIDATORS_STR}
-    __cribo_module.HEADER_VALIDATORS = HEADER_VALIDATORS
+    _cribo_module.HEADER_VALIDATORS = HEADER_VALIDATORS
 
     def process_headers(headers):
         """Example function that uses the validators."""
         return f"Processing {len(headers)} headers with validators"
-    __cribo_module.process_headers = process_headers
-    return __cribo_module
-pkg._internal = __cribo_init___cribo_73cafd_pkg__internal()
+    _cribo_module.process_headers = process_headers
+    return _cribo_module
+pkg._internal = _cribo_init___cribo_73cafd_pkg__internal()
 def get_validators():
     """Return the validators."""
     assert pkg._internal._HEADER_VALIDATORS_BYTE is not None

--- a/crates/cribo/tests/snapshots/bundled_code@pydantic_project.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pydantic_project.snap
@@ -12,11 +12,11 @@ import types
 import typing
 schemas = types.SimpleNamespace(__name__='schemas')
 @functools.cache
-def __cribo_init___cribo_f275a8_schemas_user():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'schemas.user'
+def _cribo_init___cribo_f275a8_schemas_user():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'schemas.user'
     Optional = typing.Optional
-    __cribo_module.Optional = Optional
+    _cribo_module.Optional = Optional
     """User schema definitions using Pydantic."""
     from pydantic import BaseModel, EmailStr, Field
 
@@ -33,7 +33,7 @@ def __cribo_init___cribo_f275a8_schemas_user():
             json_encoders = {}
             json_schema_extra = {"example": {"name": "John Doe", "email": "john@example.com", "age": 30, "is_active": True, "bio": "Software developer"}}
     UserSchema.__module__ = 'schemas.user'
-    __cribo_module.UserSchema = UserSchema
+    _cribo_module.UserSchema = UserSchema
 
     class CreateUserRequest(BaseModel):
         """Request model for creating a new user."""
@@ -42,7 +42,7 @@ def __cribo_init___cribo_f275a8_schemas_user():
         age: typing.Optional[int] = Field(default=None, ge=0, le=150)
         bio: typing.Optional[str] = Field(default=None, max_length=500)
     CreateUserRequest.__module__ = 'schemas.user'
-    __cribo_module.CreateUserRequest = CreateUserRequest
+    _cribo_module.CreateUserRequest = CreateUserRequest
 
     class UserResponse(BaseModel):
         """Response model for user data."""
@@ -53,9 +53,9 @@ def __cribo_init___cribo_f275a8_schemas_user():
         is_active: bool
         bio: typing.Optional[str] = None
     UserResponse.__module__ = 'schemas.user'
-    __cribo_module.UserResponse = UserResponse
-    return __cribo_module
-schemas.user = __cribo_init___cribo_f275a8_schemas_user()
+    _cribo_module.UserResponse = UserResponse
+    return _cribo_module
+schemas.user = _cribo_init___cribo_f275a8_schemas_user()
 def validate_email(email: str) -> bool:
     """Simple email validation."""
     pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"

--- a/crates/cribo/tests/snapshots/bundled_code@stdlib_decorator.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stdlib_decorator.snap
@@ -13,9 +13,9 @@ import tempfile
 import types
 mypackage = types.SimpleNamespace(__name__='mypackage')
 @functools.cache
-def __cribo_init___cribo_7c69fc_mypackage_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.utils'
+def _cribo_init___cribo_7c69fc_mypackage_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.utils'
     """Utils module with contextlib decorator.\n\nThis module must have side effects to become a wrapper module,\nand uses contextlib as a decorator which should be preserved in\nthe init function but currently isn't.\n"""
     print("Loading utils module")
 
@@ -31,20 +31,20 @@ def __cribo_init___cribo_7c69fc_mypackage_utils():
         except BaseException:
             os.remove(tmp_name)
             raise
-    __cribo_module.atomic_open = atomic_open
-    return __cribo_module
+    _cribo_module.atomic_open = atomic_open
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_41b947_mypackage():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage'
+def _cribo_init___cribo_41b947_mypackage():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage'
     """Package init file."""
-    mypackage.utils = __cribo_init___cribo_7c69fc_mypackage_utils()
+    mypackage.utils = _cribo_init___cribo_7c69fc_mypackage_utils()
     utils = mypackage.utils
-    __cribo_module.utils = utils
+    _cribo_module.utils = utils
     print("Loading mypackage")
-    return __cribo_module
+    return _cribo_module
 """Test contextlib import missing in wrapper module init functions.\n\nThis test reproduces the bug found when bundling requests where contextlib\nis used as @contextlib.contextmanager decorator but not imported in the\ngenerated init function for wrapper modules with side effects.\n"""
-__cribo_init_result = __cribo_init___cribo_41b947_mypackage()
+__cribo_init_result = _cribo_init___cribo_41b947_mypackage()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(mypackage, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@stdlib_hoisting_aliases.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@stdlib_hoisting_aliases.snap
@@ -27,34 +27,34 @@ def get_mock_file_info() -> dict:
     return json.loads(json.dumps(info))
 """File utilities module - no side effects, uses aliased stdlib imports."""
 @functools.cache
-def __cribo_init___cribo_60bb0a_logger():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'logger'
+def _cribo_init___cribo_60bb0a_logger():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'logger'
     json_stringify = json.dumps
-    __cribo_module.json_stringify = json_stringify
+    _cribo_module.json_stringify = json_stringify
     ODict = collections.OrderedDict
-    __cribo_module.ODict = ODict
+    _cribo_module.ODict = ODict
     """Logger module - has side effects (print), uses different aliased stdlib imports."""
     print("Initializing logger module...")
     logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
-    logger = logging.getLogger(__cribo_module.__name__)
-    __cribo_module.logger = logger
+    logger = logging.getLogger(_cribo_module.__name__)
+    _cribo_module.logger = logger
 
     def log_message(message: str) -> None:
         """Log a message using aliased logging module."""
-        __cribo_module.logger.info(f"[ALIASED LOG] {message}")
+        _cribo_module.logger.info(f"[ALIASED LOG] {message}")
         sys.stdout.write(f"[STDOUT] {message}\n")
         sys.stdout.flush()
-    __cribo_module.log_message = log_message
+    _cribo_module.log_message = log_message
 
     def get_logger_info() -> str:
         """Get information about the logger configuration."""
         info = collections.OrderedDict([("python_version", "3.12.0"), ("logger_name", logger.name), ("log_level", logging.getLevelName(logger.level)), ("handlers", len(logger.handlers))])
         return json.dumps(info, indent=2)
-    __cribo_module.get_logger_info = get_logger_info
-    return __cribo_module
+    _cribo_module.get_logger_info = get_logger_info
+    return _cribo_module
 """Test stdlib hoisting with aliases and renamed imports."""
-logger = __cribo_init___cribo_60bb0a_logger()
+logger = _cribo_init___cribo_60bb0a_logger()
 log_message = logger.log_message
 get_logger_info = logger.get_logger_info
 dir_name = get_current_directory()

--- a/crates/cribo/tests/snapshots/bundled_code@submodule_imports_parent_function.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@submodule_imports_parent_function.snap
@@ -13,24 +13,24 @@ base_value = "base"
 def get_base():
     return base_value
 def get_result():
-    pkg.submodule = __cribo_init___cribo_dca395_pkg_submodule()
+    pkg.submodule = _cribo_init___cribo_dca395_pkg_submodule()
     return pkg.submodule.process()
 """Package __init__ that gets inlined (not wrapped)."""
 pkg.base_value = base_value
 pkg.get_base = get_base
 pkg.get_result = get_result
 @functools.cache
-def __cribo_init___cribo_dca395_pkg_submodule():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg.submodule'
+def _cribo_init___cribo_dca395_pkg_submodule():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg.submodule'
     """Submodule that becomes a wrapper module due to module-level import from parent."""
-    __cribo_module.get_base = get_base
+    _cribo_module.get_base = get_base
     computed_value = f"computed: {get_base()}"
-    __cribo_module.computed_value = computed_value
+    _cribo_module.computed_value = computed_value
 
     def process():
-        return __cribo_module.computed_value
-    __cribo_module.process = process
-    return __cribo_module
+        return _cribo_module.computed_value
+    _cribo_module.process = process
+    return _cribo_module
 """Test where submodule imports function from parent package.\n\nThis test works in Python but fails when bundled because:\n1. pkg.submodule imports get_base from parent at module level\n2. pkg.submodule uses the imported function at module level\n3. The bundler fails to properly initialize pkg.submodule\n4. When get_result() tries to access pkg.submodule.process(), it fails\n"""
 print(pkg.get_result())

--- a/crates/cribo/tests/snapshots/bundled_code@tree_shake_side_effect_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@tree_shake_side_effect_import.snap
@@ -17,29 +17,29 @@ class CustomError(Exception):
     pass
 CustomError.__module__ = 'mypackage.exceptions'
 @functools.cache
-def __cribo_init___cribo_ddd935_mypackage():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage'
+def _cribo_init___cribo_ddd935_mypackage():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage'
     print("mypackage initialized")
-    __cribo_module.exceptions = mypackage_exceptions
-    return __cribo_module
+    _cribo_module.exceptions = mypackage_exceptions
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_09b9b3_mypackage_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'mypackage.utils'
-    __cribo_module.CustomError = CustomError
+def _cribo_init___cribo_09b9b3_mypackage_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'mypackage.utils'
+    _cribo_module.CustomError = CustomError
     DEFAULT_PATH = os.environ.get("DEFAULT_PATH", "/tmp")
-    __cribo_module.DEFAULT_PATH = DEFAULT_PATH
+    _cribo_module.DEFAULT_PATH = DEFAULT_PATH
 
     def process_data(data):
         """Process data, raising CustomError if data is None."""
         if data is None:
             raise CustomError("Data cannot be None")
         return f"Processed: {data}"
-    __cribo_module.process_data = process_data
-    return __cribo_module
-mypackage.utils = __cribo_init___cribo_09b9b3_mypackage_utils()
-__cribo_init_result = __cribo_init___cribo_ddd935_mypackage()
+    _cribo_module.process_data = process_data
+    return _cribo_module
+mypackage.utils = _cribo_init___cribo_09b9b3_mypackage_utils()
+__cribo_init_result = _cribo_init___cribo_ddd935_mypackage()
 for attr in dir(__cribo_init_result):
     if not attr.startswith('_'):
         setattr(mypackage, attr, getattr(__cribo_init_result, attr))

--- a/crates/cribo/tests/snapshots/bundled_code@wildcard_all_setattr.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@wildcard_all_setattr.snap
@@ -30,26 +30,26 @@ package__subpackage.module_b = package__subpackage_module_b
 package__subpackage_module_a = types.SimpleNamespace(__name__='package._subpackage.module_a')
 package__subpackage.module_a = package__subpackage_module_a
 @functools.cache
-def __cribo_init___cribo_cca96f_package():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'package'
+def _cribo_init___cribo_cca96f_package():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'package'
     global MyClass, my_function
-    __cribo_module.MyClass = MyClass
-    __cribo_module.my_function = my_function
+    _cribo_module.MyClass = MyClass
+    _cribo_module.my_function = my_function
     """Package using wildcard imports and setattr pattern like httpx."""
     __all__ = ["MyClass", "my_function"]
-    __locals = vars(__cribo_module)
-    __cribo_module.__locals = __locals
+    __locals = vars(_cribo_module)
+    _cribo_module.__locals = __locals
     for __name in __all__:
         if not __name.startswith("__"):
             setattr(__locals[__name], "__module__", "package")
-    __cribo_module._subpackage = package__subpackage
-    return __cribo_module
-package = __cribo_init___cribo_cca96f_package()
+    _cribo_module._subpackage = package__subpackage
+    return _cribo_module
+package = _cribo_init___cribo_cca96f_package()
 package__subpackage_module_b.my_function = my_function
 package__subpackage_module_a.MyClass = MyClass
 """Test wildcard imports with __all__ and setattr pattern."""
-package = __cribo_init___cribo_cca96f_package()
+package = _cribo_init___cribo_cca96f_package()
 MyClass = package.MyClass
 my_function = package.my_function
 obj = MyClass()

--- a/crates/cribo/tests/snapshots/bundled_code@wildcard_imports.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@wildcard_imports.snap
@@ -52,19 +52,19 @@ SharedClass_2.__qualname__ = 'SharedClass'
 SafeClass.__module__ = 'explicit_all'
 """Module with no side-effects and explicit __all__."""
 @functools.cache
-def __cribo_init___cribo_9a9871_with_side_effects():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'with_side_effects'
+def _cribo_init___cribo_9a9871_with_side_effects():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'with_side_effects'
     """Module with side-effects and no explicit __all__."""
     print("Loading with_side_effects module")
     _module_state = []
-    __cribo_module._module_state = _module_state
+    _cribo_module._module_state = _module_state
     _module_state.append("initialized")
 
     def effect_function():
         """Function from module with side-effects."""
         return "effect_function_result"
-    __cribo_module.effect_function = effect_function
+    _cribo_module.effect_function = effect_function
 
     class EffectClass:
         """Class from module with side-effects."""
@@ -76,34 +76,34 @@ def __cribo_init___cribo_9a9871_with_side_effects():
         def method(self):
             return "EffectClass.method_result"
     EffectClass.__module__ = 'with_side_effects'
-    __cribo_module.EffectClass = EffectClass
+    _cribo_module.EffectClass = EffectClass
     EFFECT_CONSTANT = "EFFECT_VALUE"
-    __cribo_module.EFFECT_CONSTANT = EFFECT_CONSTANT
+    _cribo_module.EFFECT_CONSTANT = EFFECT_CONSTANT
     _registry = {}
-    __cribo_module._registry = _registry
+    _cribo_module._registry = _registry
 
     def register(name):
         """Decorator with side-effects."""
 
         def decorator(func):
-            __cribo_module._registry[name] = func
+            _cribo_module._registry[name] = func
             return func
         return decorator
-    __cribo_module.register = register
+    _cribo_module.register = register
 
     @register("sample")
     def registered_function():
         """Function registered as a side-effect."""
         return "registered_result"
-    __cribo_module.registered_function = registered_function
+    _cribo_module.registered_function = registered_function
     if len(_module_state) > 0:
         print(f"Module state initialized with {len(_module_state)} items")
-    return __cribo_module
+    return _cribo_module
 """Main module demonstrating various wildcard import patterns."""
 safe_function = safe_function
 SafeClass = SafeClass
 SAFE_CONSTANT = SAFE_CONSTANT
-with_side_effects = __cribo_init___cribo_9a9871_with_side_effects()
+with_side_effects = _cribo_init___cribo_9a9871_with_side_effects()
 EFFECT_CONSTANT = with_side_effects.EFFECT_CONSTANT
 EffectClass = with_side_effects.EffectClass
 effect_function = with_side_effects.effect_function

--- a/crates/cribo/tests/snapshots/bundled_code@wildcard_metaclass_ordering.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@wildcard_metaclass_ordering.snap
@@ -68,18 +68,18 @@ FullLoader.__module__ = 'yaml_module.loader'
 UnsafeLoader.__module__ = 'yaml_module.loader'
 SafeLoader.__module__ = 'yaml_module.loader'
 @functools.cache
-def __cribo_init___cribo_952a76_yaml_module():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'yaml_module'
+def _cribo_init___cribo_952a76_yaml_module():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'yaml_module'
     global BaseDumper, BaseLoader, Dumper, FullLoader, Loader, SafeDumper, SafeLoader, UnsafeLoader
-    __cribo_module.BaseDumper = BaseDumper
-    __cribo_module.BaseLoader = BaseLoader
-    __cribo_module.Dumper = Dumper
-    __cribo_module.FullLoader = FullLoader
-    __cribo_module.Loader = Loader
-    __cribo_module.SafeDumper = SafeDumper
-    __cribo_module.SafeLoader = SafeLoader
-    __cribo_module.UnsafeLoader = UnsafeLoader
+    _cribo_module.BaseDumper = BaseDumper
+    _cribo_module.BaseLoader = BaseLoader
+    _cribo_module.Dumper = Dumper
+    _cribo_module.FullLoader = FullLoader
+    _cribo_module.Loader = Loader
+    _cribo_module.SafeDumper = SafeDumper
+    _cribo_module.SafeLoader = SafeLoader
+    _cribo_module.UnsafeLoader = UnsafeLoader
 
     class YAMLObjectMetaclass(type):
         """The metaclass for YAMLObject."""
@@ -95,7 +95,7 @@ def __cribo_init___cribo_952a76_yaml_module():
                     else:
                         print(f"  - Would register with {cls.yaml_loader.__name__}")
     YAMLObjectMetaclass.__module__ = 'yaml_module'
-    __cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
+    _cribo_module.YAMLObjectMetaclass = YAMLObjectMetaclass
 
     class YAMLObject(metaclass=YAMLObjectMetaclass):
         """\n    An object that can be serialized to/from YAML.\n    Uses wildcard-imported symbols in class body.\n    """
@@ -116,10 +116,10 @@ def __cribo_init___cribo_952a76_yaml_module():
         def to_yaml(cls, dumper, data):
             return f"Dumping {cls.__name__} to YAML"
     YAMLObject.__module__ = 'yaml_module'
-    __cribo_module.YAMLObject = YAMLObject
-    __cribo_module.dumper = yaml_module_dumper
-    __cribo_module.loader = yaml_module_loader
-    return __cribo_module
+    _cribo_module.YAMLObject = YAMLObject
+    _cribo_module.dumper = yaml_module_dumper
+    _cribo_module.loader = yaml_module_loader
+    return _cribo_module
 yaml_module_dumper.BaseDumper = BaseDumper
 yaml_module_dumper.Dumper = Dumper
 yaml_module_dumper.SafeDumper = SafeDumper
@@ -129,7 +129,7 @@ yaml_module_loader.FullLoader = FullLoader
 yaml_module_loader.UnsafeLoader = UnsafeLoader
 yaml_module_loader.SafeLoader = SafeLoader
 """\nTest fixture for wildcard imports with metaclass ordering.\n\nThis tests that when using wildcard imports, symbols from __all__\nare properly included even if not directly used in the class body.\n"""
-yaml_module = __cribo_init___cribo_952a76_yaml_module()
+yaml_module = _cribo_init___cribo_952a76_yaml_module()
 assert hasattr(yaml_module, "YAMLObject")
 assert hasattr(yaml_module, "YAMLObjectMetaclass")
 print("Testing YAMLObject...")

--- a/crates/cribo/tests/snapshots/bundled_code@wrapper_module_builtin_types.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@wrapper_module_builtin_types.snap
@@ -40,22 +40,22 @@ pkg.utils = pkg_utils
 pkg_certs = types.SimpleNamespace(__name__='pkg.certs')
 pkg.certs = pkg_certs
 @functools.cache
-def __cribo_init___cribo_5a392a_pkg__internal_utils():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pkg._internal_utils'
+def _cribo_init___cribo_5a392a_pkg__internal_utils():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pkg._internal_utils'
     """Internal utils that depends on compat, creating circular dependency."""
-    __cribo_module.builtin_str = builtin_str
+    _cribo_module.builtin_str = builtin_str
     HEADER_VALIDATORS = {"str": lambda x: isinstance(x, builtin_str), "bytes": lambda x: isinstance(x, bytes)}
-    __cribo_module.HEADER_VALIDATORS = HEADER_VALIDATORS
+    _cribo_module.HEADER_VALIDATORS = HEADER_VALIDATORS
 
     def to_native_string(value):
         """Convert to native string."""
         if isinstance(value, builtin_str):
             return value
         return str(value)
-    __cribo_module.to_native_string = to_native_string
-    return __cribo_module
-pkg._internal_utils = __cribo_init___cribo_5a392a_pkg__internal_utils()
+    _cribo_module.to_native_string = to_native_string
+    return _cribo_module
+pkg._internal_utils = _cribo_init___cribo_5a392a_pkg__internal_utils()
 utils = pkg_utils
 compat = pkg_compat
 pkg_utils.process_data = process_data

--- a/crates/cribo/tests/snapshots/bundled_code@xfail_module_shadowing.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@xfail_module_shadowing.snap
@@ -9,27 +9,27 @@ input_file: crates/cribo/tests/fixtures/xfail_module_shadowing/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_b061eb_pandera():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pandera'
+def _cribo_init___cribo_b061eb_pandera():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pandera'
     """First-party module that shadows the third-party pandera package."""
     print("Loading first-party pandera module")
     __version__ = "0.0.1-local"
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
 
     def local_function():
         return "This is from the local pandera module"
-    __cribo_module.local_function = local_function
-    return __cribo_module
+    _cribo_module.local_function = local_function
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_2a6a8f_test_import():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'test_import'
+def _cribo_init___cribo_2a6a8f_test_import():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'test_import'
     """Test module that tries to import pandera.polars.\n\nThis demonstrates what happens when we have a local 'pandera' module\nthat shadows the third-party pandera package, and we try to import\na submodule that only exists in the third-party package.\n"""
     print("Starting test_import.py")
     try:
         import pandera.polars as pa
-        __cribo_module.pa = pa
+        _cribo_module.pa = pa
         print("Successfully imported pandera.polars")
         print(f"pandera.polars module: {pa.__name__}")
     except ImportError as e:
@@ -37,8 +37,8 @@ def __cribo_init___cribo_2a6a8f_test_import():
     except AttributeError as e:
         print(f"AttributeError: {e}")
     try:
-        pandera = __cribo_init___cribo_b061eb_pandera()
-        __cribo_module.pandera = pandera
+        pandera = _cribo_init___cribo_b061eb_pandera()
+        _cribo_module.pandera = pandera
         print("\nImported pandera successfully")
         print(f"pandera.__version__: {pandera.__version__}")
         if hasattr(pandera, "local_function"):
@@ -47,7 +47,7 @@ def __cribo_init___cribo_2a6a8f_test_import():
             print("This is the third-party pandera module")
     except ImportError as e:
         print(f"\nFailed to import pandera: {e}")
-    return __cribo_module
+    return _cribo_module
 """Main entry point that imports test_import to demonstrate module shadowing behavior."""
 print("=== Module Shadowing Test ===")
 print("This test demonstrates Python's behavior when a first-party module")

--- a/crates/cribo/tests/snapshots/bundled_code@xfail_module_shadowing_package.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@xfail_module_shadowing_package.snap
@@ -9,27 +9,27 @@ input_file: crates/cribo/tests/fixtures/xfail_module_shadowing_package/main.py
 import functools
 import types
 @functools.cache
-def __cribo_init___cribo_2b5490_pandera():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'pandera'
+def _cribo_init___cribo_2b5490_pandera():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'pandera'
     """First-party pandera package that shadows the third-party pandera package."""
     print("Loading first-party pandera package")
     __version__ = "0.0.1-local-package"
-    __cribo_module.__version__ = __version__
+    _cribo_module.__version__ = __version__
 
     def local_function():
         return "This is from the local pandera package"
-    __cribo_module.local_function = local_function
-    return __cribo_module
+    _cribo_module.local_function = local_function
+    return _cribo_module
 @functools.cache
-def __cribo_init___cribo_a6eb08_test_import():
-    __cribo_module = types.SimpleNamespace()
-    __cribo_module.__name__ = 'test_import'
+def _cribo_init___cribo_a6eb08_test_import():
+    _cribo_module = types.SimpleNamespace()
+    _cribo_module.__name__ = 'test_import'
     """Test module that tries to import pandera.polars.\n\nThis demonstrates what happens when we have a local 'pandera' package\nthat shadows the third-party pandera package, and we try to import\na submodule that only exists in the third-party package.\n"""
     print("Starting test_import.py")
     try:
         import pandera.polars as pa
-        __cribo_module.pa = pa
+        _cribo_module.pa = pa
         print("Successfully imported pandera.polars")
         print(f"pandera.polars module: {pa.__name__}")
     except ImportError as e:
@@ -37,8 +37,8 @@ def __cribo_init___cribo_a6eb08_test_import():
     except AttributeError as e:
         print(f"AttributeError: {e}")
     try:
-        pandera = __cribo_init___cribo_2b5490_pandera()
-        __cribo_module.pandera = pandera
+        pandera = _cribo_init___cribo_2b5490_pandera()
+        _cribo_module.pandera = pandera
         print("\nImported pandera successfully")
         print(f"pandera.__version__: {pandera.__version__}")
         if hasattr(pandera, "local_function"):
@@ -47,7 +47,7 @@ def __cribo_init___cribo_a6eb08_test_import():
             print("This is the third-party pandera package")
     except ImportError as e:
         print(f"\nFailed to import pandera: {e}")
-    return __cribo_module
+    return _cribo_module
 """Main entry point that imports test_import to demonstrate module shadowing behavior."""
 print("=== Module Shadowing Test (Package Version) ===")
 print("This test demonstrates Python's behavior when a first-party package")

--- a/crates/cribo/tests/test_bundling_snapshots.rs
+++ b/crates/cribo/tests/test_bundling_snapshots.rs
@@ -623,7 +623,7 @@ fn check_for_duplicate_lines(bundled_code: &str, fixture_name: &str) {
                 (!line.starts_with("    ") && line.contains(" = ") && !line.contains("self."))
                 )
                 // Allow duplicate init function calls since they're cached with @functools.cache
-                && !line.contains("__cribo_init_")
+                && !line.contains("_cribo_init")
         })
         .collect();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a public utility to detect initialization functions.

- Refactor
  - Centralized init-function detection into a shared utility, replacing scattered string checks.
  - Updated generated identifiers to use single leading underscores for init functions and module variables to avoid name mangling.

- Tests
  - Broadened snapshot duplicate-line checks to exclude init-related lines.

- Documentation
  - Clarified rationale for underscore usage in generated identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->