### PR TITLE
fix: handle wrapper module imports in function default parameters

### DIFF
--- a/crates/cribo/src/ast_builder/expressions.rs
+++ b/crates/cribo/src/ast_builder/expressions.rs
@@ -157,6 +157,33 @@ pub fn dotted_name(parts: &[&str], ctx: ExprContext) -> Expr {
     result
 }
 
+/// Creates a module reference expression, handling both simple and dotted names.
+///
+/// This is a convenience function that automatically chooses between creating
+/// a simple name expression or a dotted name expression based on whether the
+/// module name contains dots.
+///
+/// # Arguments
+/// * `module_name` - The module name (e.g., "math" or "os.path")
+/// * `ctx` - The expression context
+///
+/// # Example
+/// ```rust
+/// // Creates: `math` (simple name)
+/// let expr = module_reference("math", ExprContext::Load);
+///
+/// // Creates: `os.path` (dotted name)
+/// let expr = module_reference("os.path", ExprContext::Load);
+/// ```
+pub fn module_reference(module_name: &str, ctx: ExprContext) -> Expr {
+    if module_name.contains('.') {
+        let parts: Vec<&str> = module_name.split('.').collect();
+        dotted_name(&parts, ctx)
+    } else {
+        name(module_name, ctx)
+    }
+}
+
 /// Creates a list expression node.
 ///
 /// # Arguments

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -490,12 +490,7 @@ impl<'a> Bundler<'a> {
                          copying"
                     );
 
-                    let module_expr = if module_name.contains('.') {
-                        let parts: Vec<&str> = module_name.split('.').collect();
-                        expressions::dotted_name(&parts, ExprContext::Load)
-                    } else {
-                        expressions::name(module_name, ExprContext::Load)
-                    };
+                    let module_expr = expressions::module_reference(module_name, ExprContext::Load);
 
                     // Create: for __cribo_attr in dir(module):
                     //             if not __cribo_attr.startswith('_'):

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -1216,9 +1216,11 @@ impl<'a> RecursiveImportTransformer<'a> {
 
                 // Check if this is importing a submodule (like from . import config)
                 // First check if it's a wrapper submodule, then check if it's inlined
-                if self.bundler.module_registry.contains_key(&full_module_path)
-                    && !self.bundler.inlined_modules.contains(&full_module_path)
-                {
+                if crate::code_generator::module_registry::is_wrapper_submodule(
+                    &full_module_path,
+                    &self.bundler.module_registry,
+                    &self.bundler.inlined_modules,
+                ) {
                     // This is a wrapper submodule
                     log::debug!("  '{full_module_path}' is a wrapper submodule");
 

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -1233,12 +1233,8 @@ impl<'a> RecursiveImportTransformer<'a> {
                         );
 
                         // Create assignment: local_name = parent.submodule
-                        let module_expr = if full_module_path.contains('.') {
-                            let parts: Vec<&str> = full_module_path.split('.').collect();
-                            expressions::dotted_name(&parts, ExprContext::Load)
-                        } else {
-                            expressions::name(&full_module_path, ExprContext::Load)
-                        };
+                        let module_expr =
+                            expressions::module_reference(&full_module_path, ExprContext::Load);
 
                         result_stmts.push(statements::simple_assign(local_name, module_expr));
 

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -343,15 +343,21 @@ impl<'a> RecursiveImportTransformer<'a> {
                             self.transform_expr(&mut decorator.expression);
                         }
 
-                        // Transform parameter annotations
+                        // Transform parameter annotations and default values
                         for param in &mut func_def.parameters.posonlyargs {
                             if let Some(annotation) = &mut param.parameter.annotation {
                                 self.transform_expr(annotation);
+                            }
+                            if let Some(default) = &mut param.default {
+                                self.transform_expr(default);
                             }
                         }
                         for param in &mut func_def.parameters.args {
                             if let Some(annotation) = &mut param.parameter.annotation {
                                 self.transform_expr(annotation);
+                            }
+                            if let Some(default) = &mut param.default {
+                                self.transform_expr(default);
                             }
                         }
                         if let Some(vararg) = &mut func_def.parameters.vararg
@@ -362,6 +368,9 @@ impl<'a> RecursiveImportTransformer<'a> {
                         for param in &mut func_def.parameters.kwonlyargs {
                             if let Some(annotation) = &mut param.parameter.annotation {
                                 self.transform_expr(annotation);
+                            }
+                            if let Some(default) = &mut param.default {
+                                self.transform_expr(default);
                             }
                         }
                         if let Some(kwarg) = &mut func_def.parameters.kwarg
@@ -1206,7 +1215,38 @@ impl<'a> RecursiveImportTransformer<'a> {
                 );
 
                 // Check if this is importing a submodule (like from . import config)
-                if self.bundler.inlined_modules.contains(&full_module_path) {
+                // First check if it's a wrapper submodule, then check if it's inlined
+                if self.bundler.module_registry.contains_key(&full_module_path)
+                    && !self.bundler.inlined_modules.contains(&full_module_path)
+                {
+                    // This is a wrapper submodule
+                    log::debug!("  '{full_module_path}' is a wrapper submodule");
+
+                    // For wrapper modules importing wrapper submodules from the same package
+                    if self.is_wrapper_init {
+                        // Initialize the wrapper submodule if needed
+                        result_stmts.extend(
+                            self.bundler
+                                .create_module_initialization_for_import(&full_module_path),
+                        );
+
+                        // Create assignment: local_name = parent.submodule
+                        let module_expr = if full_module_path.contains('.') {
+                            let parts: Vec<&str> = full_module_path.split('.').collect();
+                            expressions::dotted_name(&parts, ExprContext::Load)
+                        } else {
+                            expressions::name(&full_module_path, ExprContext::Load)
+                        };
+
+                        result_stmts.push(statements::simple_assign(local_name, module_expr));
+
+                        log::debug!(
+                            "  Created assignment for wrapper submodule: {local_name} = {full_module_path}"
+                        );
+
+                        handled_any = true;
+                    }
+                } else if self.bundler.inlined_modules.contains(&full_module_path) {
                     log::debug!("  '{full_module_path}' is an inlined module");
 
                     // Check if this module was namespace imported

--- a/crates/cribo/src/code_generator/import_transformer.rs
+++ b/crates/cribo/src/code_generator/import_transformer.rs
@@ -1238,9 +1238,15 @@ impl<'a> RecursiveImportTransformer<'a> {
 
                         result_stmts.push(statements::simple_assign(local_name, module_expr));
 
+                        // Track as local to avoid any accidental rewrites later in this transform pass
+                        self.local_variables.insert(local_name.to_string());
+
                         log::debug!(
                             "  Created assignment for wrapper submodule: {local_name} = {full_module_path}"
                         );
+
+                        // Note: The module attribute assignment (_cribo_module.<local_name> = ...)
+                        // is handled later in create_assignments_for_inlined_imports to avoid duplication
 
                         handled_any = true;
                     }

--- a/crates/cribo/src/code_generator/module_registry.rs
+++ b/crates/cribo/src/code_generator/module_registry.rs
@@ -434,3 +434,16 @@ pub fn register_module(
 
     (synthetic_name, init_func_name)
 }
+
+/// Check if a module is a wrapper submodule (not inlined)
+///
+/// A module is considered a wrapper submodule if:
+/// - It exists in the module registry (meaning it has an init function)
+/// - It is NOT in the inlined modules set
+pub fn is_wrapper_submodule(
+    module_path: &str,
+    module_registry: &FxIndexMap<String, String>,
+    inlined_modules: &FxIndexSet<String>,
+) -> bool {
+    module_registry.contains_key(module_path) && !inlined_modules.contains(module_path)
+}

--- a/crates/cribo/src/code_generator/namespace_manager.rs
+++ b/crates/cribo/src/code_generator/namespace_manager.rs
@@ -532,12 +532,8 @@ pub(super) fn transform_namespace_package_imports(
                 );
 
                 // Create assignment using dotted name since it's a nested module
-                let module_expr = if full_module_path.contains('.') {
-                    let parts: Vec<&str> = full_module_path.split('.').collect();
-                    expressions::dotted_name(&parts, ExprContext::Load)
-                } else {
-                    expressions::name(&full_module_path, ExprContext::Load)
-                };
+                let module_expr =
+                    expressions::module_reference(&full_module_path, ExprContext::Load);
 
                 result_stmts.push(statements::simple_assign(local_name, module_expr));
             } else {


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where wrapper modules importing both wrapper and inlined submodules would fail when the wrapper submodules were referenced in function default parameters.

## Problem

When `rich.table` did `from . import box, errors`:
- `errors` (inlined module) was processed correctly
- `box` (wrapper module) was skipped
- This caused `NameError: name 'box' is not defined` when Table class tried to use `box.Box` and `box.HEAVY_HEAD` in its `__init__` default parameters

## Solution

1. **Transform default parameter values**: Added transformation of default parameter values in function definitions to ensure module references are properly handled

2. **Fix import processing order**: Modified the import handling loop to check for wrapper submodules before inlined ones, ensuring both types are processed

3. **Create proper assignments**: Generate necessary assignments (e.g., `box = rich.box`) for wrapper submodules inside wrapper module init functions

## Test Results

- ✅ All workspace tests pass
- ✅ Clippy validation clean
- ✅ The specific `rich` ecosystem test that was failing now progresses past the `box` error

## Impact

This fix enables proper bundling of complex libraries like `rich` that use mixed import patterns with both wrapper and inlined submodules, especially when those modules are referenced in function default parameters.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Defaults for all parameter kinds are now transformed alongside annotations.
  - Added a reusable module-reference helper and a flag to signal wrapper-init mode for import handling.
  - Wrapper submodule initialization now creates a local binding to the submodule for later references.

- Bug Fixes
  - Prioritizes wrapper submodules over inlined modules during import resolution to avoid incorrect rewrites.
  - Tracks importlib-based imports for more accurate rewriting and ensures wrapper init statements run before local bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->