### PR TITLE
fix: prefer __init__.py over __main__.py for directory entry points

### DIFF
--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -368,31 +368,31 @@ impl BundleOrchestrator {
 
         // Handle directory as entry point
         let entry_path = if entry_path.is_dir() {
-            // Check for __main__.py first
-            let main_py = entry_path.join(crate::python::constants::MAIN_FILE);
-            if main_py.exists() && main_py.is_file() {
+            // Check for __init__.py first (standard package import behavior)
+            let init_py = entry_path.join(crate::python::constants::INIT_FILE);
+            if init_py.exists() && init_py.is_file() {
                 info!(
                     "Using {} as entry point from directory: {}",
-                    crate::python::constants::MAIN_FILE,
+                    crate::python::constants::INIT_FILE,
                     entry_path.display()
                 );
-                main_py
+                init_py
             } else {
-                // Check for __init__.py
-                let init_py = entry_path.join(crate::python::constants::INIT_FILE);
-                if init_py.exists() && init_py.is_file() {
+                // Check for __main__.py as fallback
+                let main_py = entry_path.join(crate::python::constants::MAIN_FILE);
+                if main_py.exists() && main_py.is_file() {
                     info!(
                         "Using {} as entry point from directory: {}",
-                        crate::python::constants::INIT_FILE,
+                        crate::python::constants::MAIN_FILE,
                         entry_path.display()
                     );
-                    init_py
+                    main_py
                 } else {
                     return Err(anyhow!(
                         "Directory {} does not contain {} or {}",
                         entry_path.display(),
-                        crate::python::constants::MAIN_FILE,
-                        crate::python::constants::INIT_FILE
+                        crate::python::constants::INIT_FILE,
+                        crate::python::constants::MAIN_FILE
                     ));
                 }
             }

--- a/crates/cribo/tests/fixtures/directory_entry_main/__init__.py
+++ b/crates/cribo/tests/fixtures/directory_entry_main/__init__.py
@@ -1,4 +1,4 @@
 """Test package that has both __main__.py and __init__.py."""
 
-# This should not be used as the entry point when __main__.py exists
-print("This is __init__.py - should not run when __main__.py exists")
+# This should be used as the entry point (preferred over __main__.py)
+print("This is __init__.py")

--- a/crates/cribo/tests/snapshots/test_cli_stdout__directory_entry_empty_stderr.snap
+++ b/crates/cribo/tests/snapshots/test_cli_stdout__directory_entry_empty_stderr.snap
@@ -2,4 +2,4 @@
 source: crates/cribo/tests/test_cli_stdout.rs
 expression: stderr
 ---
-Error: Directory <WORKSPACE> does not contain __main__.py or __init__.py
+Error: Directory <WORKSPACE> does not contain __init__.py or __main__.py

--- a/crates/cribo/tests/snapshots/test_cli_stdout__directory_entry_main_stdout.snap
+++ b/crates/cribo/tests/snapshots/test_cli_stdout__directory_entry_main_stdout.snap
@@ -28,8 +28,5 @@ class _Cribo():
         m = _sys.modules.get(n) or _importlib.import_module(n)
         return _CriboModule(m, n)
 _cribo = _Cribo()
-"""Test package with __main__.py entry point."""
-def main():
-    print("Running from __main__.py")
-if __name__ == "__main__":
-    main()
+"""Test package that has both __main__.py and __init__.py."""
+print("This is __init__.py")

--- a/crates/cribo/tests/test_cli_stdout.rs
+++ b/crates/cribo/tests/test_cli_stdout.rs
@@ -250,9 +250,9 @@ fn test_directory_entry_with_main_py() {
         assert_snapshot!("directory_entry_main_stdout", stdout);
     });
 
-    // Should contain code from __main__.py, not __init__.py
-    assert!(stdout.contains("Running from __main__.py"));
-    assert!(!stdout.contains("This is __init__.py"));
+    // Should contain code from __init__.py, not __main__.py (prefers __init__.py)
+    assert!(stdout.contains("This is __init__.py"));
+    assert!(!stdout.contains("Running from __main__.py"));
 }
 
 #[test]
@@ -293,6 +293,6 @@ fn test_directory_entry_empty_fails() {
         assert_snapshot!("directory_entry_empty_stderr", stderr);
     });
 
-    // Should contain appropriate error message
-    assert!(stderr.contains("does not contain __main__.py or __init__.py"));
+    // Should contain appropriate error message (checks __init__.py first)
+    assert!(stderr.contains("does not contain __init__.py or __main__.py"));
 }


### PR DESCRIPTION
## Summary

When a directory is specified as the entry point, the bundler now prefers `__init__.py` over `__main__.py` to match Python's standard import behavior.

## Problem

Previously, when given a directory as the entry point, the bundler would check for `__main__.py` first. This caused issues with packages that have both `__init__.py` and `__main__.py` files:

- The entry module would be registered using `__main__.py`
- But imports would find `__init__.py`
- This created duplicate module IDs for the same package
- Functions and classes defined in `__init__.py` would be missing from the bundle

## Solution

Reversed the priority to match Python's import semantics:
- `import package` → loads `package/__init__.py` (library usage)
- `python -m package` → executes `package/__main__.py` (CLI usage)

Since the bundler is primarily for bundling libraries (not CLI apps), preferring `__init__.py` is the correct default. Users who want to bundle CLI behavior can explicitly specify `package/__main__.py` as the entry.

## Test Results

This fix resolves the initial error in the `rich` ecosystem test where `get_console` and other functions from `__init__.py` were missing.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Deterministic, cycle-aware module ordering for bundling with warnings/errors for unresolvable cycles.
  - Stable module naming using content hashes and import-rewriting to resolve movable imports when possible.
  - Improved package resolution by adding the entry directory to source paths and better requirements mapping to actual package names.
- Bug Fixes
  - Directory entry resolution now prefers the package initializer file before the fallback entry.
- Refactor
  - Updated logs and messages to reflect the new entry-file priority; no public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->