### PR TITLE
fix: prevent globals() transformation in functions within circular dependency modules

### DIFF
--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -41,6 +41,8 @@ pub(super) struct BundledImportContext<'a> {
     pub inside_wrapper_init: bool,
     pub at_module_level: bool,
     pub current_module: Option<&'a str>,
+    /// Cached set of symbols used in the current function scope (if available)
+    pub current_function_used_symbols: Option<&'a FxIndexSet<String>>,
 }
 
 /// Bundler orchestrates the code generation phase of bundling
@@ -672,6 +674,7 @@ impl<'a> Bundler<'a> {
             inside_wrapper_init,
             at_module_level,
             current_module,
+            current_function_used_symbols: context.current_function_used_symbols,
         };
         crate::code_generator::import_transformer::transform_wrapper_symbol_imports(
             self,

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1672,7 +1672,8 @@ impl<'a> Bundler<'a> {
                         .clone();
 
                     let global_info = crate::analyzers::GlobalAnalyzer::analyze(mname, &ast);
-                    let is_in_circular = self.circular_modules.contains(mid);
+                    // mid is a member of the current SCC; don't rely on pruned circular_modules
+                    let is_in_circular = member_to_group.contains_key(mid);
                     let transform_ctx = ModuleTransformContext {
                         module_name: mname,
                         module_path: &path,

--- a/crates/cribo/src/code_generator/bundler.rs
+++ b/crates/cribo/src/code_generator/bundler.rs
@@ -1672,13 +1672,15 @@ impl<'a> Bundler<'a> {
                         .clone();
 
                     let global_info = crate::analyzers::GlobalAnalyzer::analyze(mname, &ast);
+                    let is_in_circular = self.circular_modules.contains(mid);
                     let transform_ctx = ModuleTransformContext {
                         module_name: mname,
                         module_path: &path,
                         global_info: global_info.clone(),
                         semantic_bundler: self.semantic_bundler,
                         python_version,
-                        is_wrapper_body: true,
+                        is_wrapper_body: true, // Keep original semantics
+                        is_in_circular_deps: is_in_circular,
                     };
 
                     let init_function = module_transformer::transform_module_to_init_function(
@@ -1924,6 +1926,9 @@ impl<'a> Bundler<'a> {
                 // Analyze global declarations for this wrapper module
                 let global_info = crate::analyzers::GlobalAnalyzer::analyze(&module_name, &ast);
 
+                // Check if this wrapper module is in circular dependencies
+                let is_in_circular = self.circular_modules.contains(&wrapper_module_id);
+
                 // Create the module transform context
                 let transform_ctx = ModuleTransformContext {
                     module_name: &module_name,
@@ -1931,7 +1936,8 @@ impl<'a> Bundler<'a> {
                     global_info: global_info.clone(),
                     semantic_bundler: self.semantic_bundler,
                     python_version,
-                    is_wrapper_body: true,
+                    is_wrapper_body: true, // Keep original semantics
+                    is_in_circular_deps: is_in_circular,
                 };
 
                 // Transform the module into an init function

--- a/crates/cribo/src/code_generator/context.rs
+++ b/crates/cribo/src/code_generator/context.rs
@@ -18,6 +18,8 @@ pub struct ModuleTransformContext<'a> {
     pub python_version: u8,
     /// Whether this module is being transformed as a wrapper function body
     pub is_wrapper_body: bool,
+    /// Whether this module is in a circular dependency chain
+    pub is_in_circular_deps: bool,
 }
 
 /// Context for inlining modules

--- a/crates/cribo/src/code_generator/globals.rs
+++ b/crates/cribo/src/code_generator/globals.rs
@@ -908,87 +908,16 @@ pub fn transform_globals_in_stmt(stmt: &mut Stmt, module_var_name: &str) {
 /// will be called later when `self` is not in scope. However, it DOES transform
 /// `globals()` in module-level code (outside functions).
 pub fn transform_globals_in_stmt_wrapper(stmt: &mut Stmt, module_var_name: &str) {
-    // For wrapper modules, we need special handling:
-    // - Transform globals() at module level (outside functions)
-    // - Do NOT transform globals() inside function bodies
     match stmt {
-        Stmt::FunctionDef(func_def) => {
-            // Transform decorators and defaults (evaluated at module level)
-            for decorator in &mut func_def.decorator_list {
-                transform_introspection_in_expr(
-                    &mut decorator.expression,
-                    Introspection::Globals,
-                    true,
-                    module_var_name,
-                );
-            }
-            if let Some(ref mut returns) = func_def.returns {
-                transform_introspection_in_expr(
-                    returns,
-                    Introspection::Globals,
-                    true,
-                    module_var_name,
-                );
-            }
-            for param in func_def
-                .parameters
-                .posonlyargs
-                .iter_mut()
-                .chain(func_def.parameters.args.iter_mut())
-                .chain(func_def.parameters.kwonlyargs.iter_mut())
-            {
-                if let Some(ref mut default) = param.default {
-                    transform_introspection_in_expr(
-                        default,
-                        Introspection::Globals,
-                        true,
-                        module_var_name,
-                    );
-                }
-                if let Some(ref mut annotation) = param.parameter.annotation {
-                    transform_introspection_in_expr(
-                        annotation,
-                        Introspection::Globals,
-                        true,
-                        module_var_name,
-                    );
-                }
-            }
-            // DO NOT transform inside function body - leave globals() as is
-            // The function will be called later when self is not in scope
-        }
-        Stmt::ClassDef(class_def) => {
-            // Transform decorators and bases (evaluated at module level)
-            for decorator in &mut class_def.decorator_list {
-                transform_introspection_in_expr(
-                    &mut decorator.expression,
-                    Introspection::Globals,
-                    true,
-                    module_var_name,
-                );
-            }
-            if let Some(ref mut arguments) = class_def.arguments {
-                for base in &mut arguments.args {
-                    transform_introspection_in_expr(
-                        base,
-                        Introspection::Globals,
-                        true,
-                        module_var_name,
-                    );
-                }
-                for keyword in &mut arguments.keywords {
-                    transform_introspection_in_expr(
-                        &mut keyword.value,
-                        Introspection::Globals,
-                        true,
-                        module_var_name,
-                    );
-                }
-            }
-            // DO NOT transform inside class body - classes also have their own scope
+        Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {
+            // For functions and classes, we only want to transform the "header"
+            // (decorators, defaults, etc.) but not recurse into the body.
+            // `transform_introspection_in_stmt` with `recurse_into_scopes = false`
+            // achieves exactly this.
+            transform_introspection_in_stmt(stmt, Introspection::Globals, false, module_var_name);
         }
         _ => {
-            // For all other statements at module level, transform normally
+            // For all other statements at module level, transform recursively.
             transform_introspection_in_stmt(stmt, Introspection::Globals, true, module_var_name);
         }
     }

--- a/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
+++ b/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
@@ -1060,8 +1060,8 @@ impl WrapperHandler {
                         // Module not yet initialized - preserve import to trigger
                         // initialization
                         log::debug!(
-                            "Preserving import for '{target_name}' from circular wrapper \
-                             module '{module_name}' - needs initialization for side effects"
+                            "Preserving import for '{target_name}' from circular wrapper module \
+                             '{module_name}' - needs initialization for side effects"
                         );
                         // Continue with normal processing to trigger initialization
                     } else if is_wrapper {

--- a/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
+++ b/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
@@ -104,6 +104,7 @@ impl WrapperHandler {
                 inside_wrapper_init: context.is_wrapper_init,
                 at_module_level: context.at_module_level,
                 current_module: Some(&context.current_module_name),
+                current_function_used_symbols: context.current_function_used_symbols,
             };
             return context
                 .bundler
@@ -121,6 +122,7 @@ impl WrapperHandler {
             inside_wrapper_init: context.is_wrapper_init,
             at_module_level: context.at_module_level,
             current_module: Some(&context.current_module_name),
+            current_function_used_symbols: context.current_function_used_symbols,
         };
         context
             .bundler
@@ -153,7 +155,7 @@ impl WrapperHandler {
             at_module_level: context.at_module_level,
             current_module_name: context.current_module.unwrap_or("").to_string(),
             function_body,
-            current_function_used_symbols: None, // Not available from old context
+            current_function_used_symbols: context.current_function_used_symbols,
         };
 
         Self::handle_symbol_imports_from_wrapper(&wrapper_context, import_from, module_name)

--- a/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
+++ b/crates/cribo/src/code_generator/import_transformer/handlers/wrapper.rs
@@ -1030,7 +1030,7 @@ impl WrapperHandler {
                     let is_wrapper =
                         module_id.is_some_and(|id| bundler.wrapper_modules.contains(&id));
                     let wrapper_is_circular =
-                        module_id.is_some_and(|id| bundler.circular_modules.contains(&id));
+                        module_id.is_some_and(|id| bundler.is_module_in_circular_deps(id));
 
                     // Only skip for inlined modules where we're certain about usage
                     // For wrapper modules, we need to be more careful about side effects

--- a/crates/cribo/src/code_generator/import_transformer/mod.rs
+++ b/crates/cribo/src/code_generator/import_transformer/mod.rs
@@ -1105,6 +1105,7 @@ impl<'a> RecursiveImportTransformer<'a> {
             at_module_level: self.state.at_module_level,
             python_version: self.state.python_version,
             function_body: self.state.current_function_body.as_deref(),
+            current_function_used_symbols: self.state.current_function_used_symbols.as_ref(),
         })
     }
 
@@ -1568,6 +1569,7 @@ struct RewriteImportFromParams<'a> {
     at_module_level: bool,
     python_version: u8,
     function_body: Option<&'a [Stmt]>,
+    current_function_used_symbols: Option<&'a FxIndexSet<String>>,
 }
 
 /// Rewrite import from statement with proper handling for bundled modules
@@ -1582,6 +1584,7 @@ fn rewrite_import_from(params: RewriteImportFromParams) -> Vec<Stmt> {
         at_module_level,
         python_version,
         function_body,
+        current_function_used_symbols,
     } = params;
     // Resolve relative imports to absolute module names
     log::debug!(
@@ -1692,6 +1695,7 @@ fn rewrite_import_from(params: RewriteImportFromParams) -> Vec<Stmt> {
             at_module_level,
             current_module_name: current_module.to_string(),
             function_body,
+            current_function_used_symbols,
         };
         if let Some(stmts) = handlers::wrapper::WrapperHandler::maybe_handle_wrapper_absolute(
             &context,
@@ -1748,6 +1752,7 @@ fn rewrite_import_from(params: RewriteImportFromParams) -> Vec<Stmt> {
             at_module_level,
             current_module_name: current_module.to_string(),
             function_body,
+            current_function_used_symbols,
         };
         handlers::wrapper::WrapperHandler::handle_wrapper_from_import_absolute_context(
             &context,

--- a/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_mixed_collisions.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@ast_rewriting_mixed_collisions.snap
@@ -432,9 +432,9 @@ def _cribo_init___cribo_bca2f6_models_base(self):
     def shadow_test(validate: _cribo.typing.Any=None, process: _cribo.typing.Any=None, Logger: _cribo.typing.Any=None, result: _cribo.typing.Any=None, initialize: _cribo.typing.Any=None) -> _cribo.typing.Dict[str, _cribo.typing.Any]:
         """Function that shadows all major conflict names with parameters"""
         shadows = {"validate_param": validate, "process_param": process, "Logger_param": Logger, "result_param": result, "initialize_param": initialize}
-        validate = self.__dict__["validate"]
-        process = self.__dict__["process"]
-        Logger = self.__dict__["Logger"]
+        validate = globals()["validate"]
+        process = globals()["process"]
+        Logger = globals()["Logger"]
         validation_result = validate("test_data")
         process_result = process("test_data")
         logger = Logger("shadow_test")

--- a/crates/cribo/tests/snapshots/bundled_code@circular_dep_with_version_module.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@circular_dep_with_version_module.snap
@@ -74,7 +74,7 @@ def _cribo_init___cribo_cc4906_package_module_a(self):
     """Module A that creates circular dependency"""
 
     def func_a():
-        package_func = _cribo_init___cribo_a4c23d_package(package).package_func
+        package_func = _cribo_init___cribo_a4c23d_package(globals()['package']).package_func
         return "func_a"
     self.func_a = func_a
 

--- a/crates/cribo/tests/snapshots/bundled_code@circular_deps_with_stdlib_name_conflict.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@circular_deps_with_stdlib_name_conflict.snap
@@ -146,7 +146,7 @@ def _cribo_init___cribo_02808e_pkg_color(self):
 
     def color_from_style(style) -> "Color":
         """Create a color from a style."""
-        Style = _cribo_init___cribo_4c91ba_pkg_style(self.__dict__['pkg_style']).Style
+        Style = _cribo_init___cribo_4c91ba_pkg_style(globals()['pkg_style']).Style
         if style.color == "red":
             return Color(255, 0, 0)
         elif style.color == "green":
@@ -158,7 +158,7 @@ def _cribo_init___cribo_02808e_pkg_color(self):
 
     def apply_color_to_console(console, color: Color) -> None:
         """Apply color to console."""
-        ConsoleBase = _cribo_init___cribo_f0224b_pkg_console(self.__dict__['pkg_console']).ConsoleBase
+        ConsoleBase = _cribo_init___cribo_f0224b_pkg_console(globals()['pkg_console']).ConsoleBase
         pass
     self.apply_color_to_console = apply_color_to_console
     self.Optional = _cribo.typing.Optional
@@ -320,7 +320,7 @@ def _cribo_init___cribo_4c91ba_pkg_style(self):
 
     def apply_style_to_console(console, style: Style) -> None:
         """Apply a style to console output."""
-        ConsoleBase = _cribo_init___cribo_f0224b_pkg_console(self.__dict__['pkg_console']).ConsoleBase
+        ConsoleBase = _cribo_init___cribo_f0224b_pkg_console(globals()['pkg_console']).ConsoleBase
         pass
     self.apply_style_to_console = apply_style_to_console
     self.Optional = _cribo.typing.Optional

--- a/crates/cribo/tests/snapshots/bundled_code@cross_package_mixed_import.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@cross_package_mixed_import.snap
@@ -308,7 +308,7 @@ def _cribo_init___cribo_782908_core_database(self):
 
     def safe_connect(database_name: str) -> str:
         """Connect only if core is initialized."""
-        is_initialized = _cribo_init___cribo_f00e4b_core(core).is_initialized
+        is_initialized = _cribo_init___cribo_f00e4b_core(self.__dict__['core']).is_initialized
         if not is_initialized():
             raise RuntimeError("Core package must be initialized before connecting")
         return connect(database_name)

--- a/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@forward_reference_requests_compat.snap
@@ -233,7 +233,7 @@ def _cribo_init___cribo_ce8acb_myrequests_utils(self):
         try:
             return _cribo.json.loads(content)
         except (ValueError, TypeError) as e:
-            OurJSONDecodeError = _cribo_init___cribo_530a30_myrequests_exceptions(self.__dict__['myrequests_exceptions']).JSONDecodeError
+            OurJSONDecodeError = _cribo_init___cribo_530a30_myrequests_exceptions(globals()['myrequests_exceptions']).JSONDecodeError
             raise OurJSONDecodeError(str(e))
     self.decode_json = decode_json
     self.__initialized__ = True

--- a/crates/cribo/tests/snapshots/bundled_code@mixed_import_patterns.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@mixed_import_patterns.snap
@@ -122,7 +122,7 @@ def _cribo_init___cribo_0639af_logger(self):
 
         def configure(self):
             """Configure logger with settings from config module"""
-            get_log_level = _cribo_init___cribo_f96d2c_config(config).get_log_level
+            get_log_level = _cribo_init___cribo_f96d2c_config(globals()['config']).get_log_level
             self.log_level = get_log_level()
             self.log(f"Logger configured with level: {self.log_level}")
 

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_four_module_cycle.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_four_module_cycle.snap
@@ -41,13 +41,13 @@ def _cribo_init___cribo_1444c2_module_a(self):
 
     def start_process():
         """Start the processing chain A -> B -> C -> D -> A"""
-        process_in_b = _cribo_init___cribo_277dcc_module_b(module_b).process_in_b
+        process_in_b = _cribo_init___cribo_277dcc_module_b(globals()['module_b']).process_in_b
         return f"A({process_in_b()})"
     self.start_process = start_process
 
     def final_step():
         """Final step called by module_d to complete the cycle"""
-        process_in_b = _cribo_init___cribo_277dcc_module_b(module_b).process_in_b
+        process_in_b = _cribo_init___cribo_277dcc_module_b(globals()['module_b']).process_in_b
         return "A_final"
     self.final_step = final_step
     self.__initialized__ = True
@@ -63,12 +63,12 @@ def _cribo_init___cribo_277dcc_module_b(self):
 
     def process_in_b():
         """Process in B, depends on C"""
-        process_in_c = _cribo_init___cribo_21fc08_module_c(module_c).process_in_c
+        process_in_c = _cribo_init___cribo_21fc08_module_c(globals()['module_c']).process_in_c
         return f"B({process_in_c()})"
     self.process_in_b = process_in_b
 
     def step_b():
-        process_in_c = _cribo_init___cribo_21fc08_module_c(module_c).process_in_c
+        process_in_c = _cribo_init___cribo_21fc08_module_c(globals()['module_c']).process_in_c
         return "B_step"
     self.step_b = step_b
     self.__initialized__ = True
@@ -84,12 +84,12 @@ def _cribo_init___cribo_21fc08_module_c(self):
 
     def process_in_c():
         """Process in C, depends on D"""
-        process_in_d = _cribo_init___cribo_f1543a_module_d(module_d).process_in_d
+        process_in_d = _cribo_init___cribo_f1543a_module_d(globals()['module_d']).process_in_d
         return f"C({process_in_d()})"
     self.process_in_c = process_in_c
 
     def step_c():
-        process_in_d = _cribo_init___cribo_f1543a_module_d(module_d).process_in_d
+        process_in_d = _cribo_init___cribo_f1543a_module_d(globals()['module_d']).process_in_d
         return "C_step"
     self.step_c = step_c
     self.__initialized__ = True
@@ -105,12 +105,12 @@ def _cribo_init___cribo_f1543a_module_d(self):
 
     def process_in_d():
         """Process in D, depends back on A - completes the 4-module cycle"""
-        final_step = _cribo_init___cribo_1444c2_module_a(module_a).final_step
+        final_step = _cribo_init___cribo_1444c2_module_a(globals()['module_a']).final_step
         return f"D({final_step()})"
     self.process_in_d = process_in_d
 
     def step_d():
-        final_step = _cribo_init___cribo_1444c2_module_a(module_a).final_step
+        final_step = _cribo_init___cribo_1444c2_module_a(globals()['module_a']).final_step
         return "D_step"
     self.step_d = step_d
     self.__initialized__ = True

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_package_level_cycles.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_package_level_cycles.snap
@@ -39,13 +39,13 @@ def _cribo_init___cribo_176078_pkg1(self):
 
     def main_function():
         """Main function that uses helper from pkg2"""
-        helper_function = _cribo_init___cribo_a6e036_pkg2(pkg2).helper_function
+        helper_function = _cribo_init___cribo_a6e036_pkg2(globals()['pkg2']).helper_function
         return f"pkg1.main({helper_function()})"
     self.main_function = main_function
 
     def utility_function():
         """Utility that pkg2 will import"""
-        helper_function = _cribo_init___cribo_a6e036_pkg2(pkg2).helper_function
+        helper_function = _cribo_init___cribo_a6e036_pkg2(globals()['pkg2']).helper_function
         return "pkg1_utility"
     self.utility_function = utility_function
     self.__initialized__ = True
@@ -61,14 +61,14 @@ def _cribo_init___cribo_a6e036_pkg2(self):
 
     def helper_function():
         """Helper function that depends on pkg1"""
-        utility_function = _cribo_init___cribo_176078_pkg1(pkg1).utility_function
+        utility_function = _cribo_init___cribo_176078_pkg1(globals()['pkg1']).utility_function
         util_result = utility_function()
         return f"pkg2.helper(using_{util_result})"
     self.helper_function = helper_function
 
     def another_helper():
         """Another function in pkg2"""
-        utility_function = _cribo_init___cribo_176078_pkg1(pkg1).utility_function
+        utility_function = _cribo_init___cribo_176078_pkg1(globals()['pkg1']).utility_function
         return "pkg2_helper"
     self.another_helper = another_helper
     self.__initialized__ = True

--- a/crates/cribo/tests/snapshots/bundled_code@pyfail_three_module_cycle.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@pyfail_three_module_cycle.snap
@@ -40,12 +40,12 @@ def _cribo_init___cribo_ae45fc_module_a(self):
 
     def process_a():
         """Process A that depends on B"""
-        process_b = _cribo_init___cribo_afa23a_module_b(module_b).process_b
+        process_b = _cribo_init___cribo_afa23a_module_b(globals()['module_b']).process_b
         return process_b() + "->A"
     self.process_a = process_a
 
     def get_value_a():
-        process_b = _cribo_init___cribo_afa23a_module_b(module_b).process_b
+        process_b = _cribo_init___cribo_afa23a_module_b(globals()['module_b']).process_b
         return "value_from_A"
     self.get_value_a = get_value_a
     self.__initialized__ = True
@@ -61,12 +61,12 @@ def _cribo_init___cribo_afa23a_module_b(self):
 
     def process_b():
         """Process B that depends on C"""
-        process_c = _cribo_init___cribo_b6d812_module_c(module_c).process_c
+        process_c = _cribo_init___cribo_b6d812_module_c(globals()['module_c']).process_c
         return process_c() + "->B"
     self.process_b = process_b
 
     def get_value_b():
-        process_c = _cribo_init___cribo_b6d812_module_c(module_c).process_c
+        process_c = _cribo_init___cribo_b6d812_module_c(globals()['module_c']).process_c
         return "value_from_B"
     self.get_value_b = get_value_b
     self.__initialized__ = True
@@ -82,13 +82,13 @@ def _cribo_init___cribo_b6d812_module_c(self):
 
     def process_c():
         """Process C that depends back on A - creates the cycle"""
-        get_value_a = _cribo_init___cribo_ae45fc_module_a(module_a).get_value_a
+        get_value_a = _cribo_init___cribo_ae45fc_module_a(globals()['module_a']).get_value_a
         value = get_value_a()
         return f"C(using_{value})"
     self.process_c = process_c
 
     def get_value_c():
-        get_value_a = _cribo_init___cribo_ae45fc_module_a(module_a).get_value_a
+        get_value_a = _cribo_init___cribo_ae45fc_module_a(globals()['module_a']).get_value_a
         return "value_from_C"
     self.get_value_c = get_value_c
     self.__initialized__ = True

--- a/crates/cribo/tests/snapshots/bundled_code@symlink_circular_dependency.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@symlink_circular_dependency.snap
@@ -38,7 +38,7 @@ def _cribo_init___cribo_895222_moduleA(self):
     self.__initializing__ = True
 
     def funcA():
-        funcB = _cribo_init___cribo_19d6d4_moduleB(moduleB).funcB
+        funcB = _cribo_init___cribo_19d6d4_moduleB(globals()['moduleB']).funcB
         return f"A calls {funcB()}"
     self.funcA = funcA
 

--- a/crates/cribo/tests/snapshots/bundled_code@symlink_multi_circular.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@symlink_multi_circular.snap
@@ -38,7 +38,7 @@ def _cribo_init___cribo_5676b5_real_a(self):
     self.__initializing__ = True
 
     def start_chain():
-        from_b = _cribo_init___cribo_85e139_real_b(real_b).from_b
+        from_b = _cribo_init___cribo_85e139_real_b(globals()['real_b']).from_b
         return f"A -> {from_b()}"
     self.start_chain = start_chain
 
@@ -55,7 +55,7 @@ def _cribo_init___cribo_5676b5_real_a(self):
     self.from_e = from_e
 
     def unused_function_a():
-        unused_function_b = _cribo_init___cribo_85e139_real_b(real_b).unused_function_b
+        unused_function_b = _cribo_init___cribo_85e139_real_b(globals()['real_b']).unused_function_b
         return f"Unused A -> {unused_function_b()}"
     self.unused_function_a = unused_function_a
 
@@ -78,18 +78,18 @@ def _cribo_init___cribo_85e139_real_b(self):
     self.__initializing__ = True
 
     def from_b():
-        from_c = _cribo_init___cribo_5676b5_real_a(real_a).from_c
+        from_c = _cribo_init___cribo_5676b5_real_a(globals()['real_a']).from_c
         return f"B -> {from_c()} -> {continue_chain()}"
     self.from_b = from_b
 
     def continue_chain():
-        from_d = real_b.from_d
+        from_d = _cribo_init___cribo_85e139_real_b(globals()['real_b']).from_d
         self.from_d = from_d
         return from_d()
     self.continue_chain = continue_chain
 
     def from_d():
-        from_e = _cribo_init___cribo_5676b5_real_a(real_a).from_e
+        from_e = _cribo_init___cribo_5676b5_real_a(globals()['real_a']).from_e
         return f"D(->B) -> {from_e()}"
     self.from_d = from_d
 
@@ -98,15 +98,15 @@ def _cribo_init___cribo_85e139_real_b(self):
     self.unused_function_b = unused_function_b
 
     def unused_with_symlink():
-        unused_function_a = _cribo_init___cribo_5676b5_real_a(real_a).unused_function_a
-        from_a = _cribo_init___cribo_5676b5_real_a(real_a).from_a
+        unused_function_a = _cribo_init___cribo_5676b5_real_a(globals()['real_a']).unused_function_a
+        from_a = _cribo_init___cribo_5676b5_real_a(globals()['real_a']).from_a
         return f"Unused symlink -> {from_a()}"
     self.unused_with_symlink = unused_with_symlink
 
     class UnusedClass:
 
         def __init__(self):
-            from_c = _cribo_init___cribo_5676b5_real_a(real_a).from_c
+            from_c = _cribo_init___cribo_5676b5_real_a(globals()['real_a']).from_c
             self.value = from_c()
 
         def get_value(self):


### PR DESCRIPTION
## Summary

This PR fixes an issue where `globals()` calls inside functions in modules with circular dependencies were being incorrectly transformed to `self.__dict__`. Since these functions are called after the wrapper init completes (when `self` is no longer in scope), this transformation caused runtime errors.

## Problem

When a module has circular dependencies, it gets wrapped in an init function. Previously, we were transforming ALL `globals()` calls to `self.__dict__` in these wrapper modules. However, functions defined in these modules are called later, outside the init context, where `self` is not available.

This was causing issues in libraries like `rich` that have circular imports where functions use `globals()` to dynamically access module-level symbols.

## Solution

The fix introduces a new context field `is_in_circular_deps` to distinguish between:
1. Wrapper modules due to circular dependencies (where we should NOT transform `globals()` in functions)
2. Wrapper modules due to side effects only (where we CAN transform `globals()` normally)

Only modules with actual circular dependencies skip the `globals()` transformation inside function bodies, while still transforming `globals()` at the module level.

## Changes

- Added `is_in_circular_deps` field to `ModuleTransformContext`
- Created `transform_globals_in_stmt_wrapper()` function that skips transformation in function/class bodies
- Updated module transformation logic to use the wrapper version only for circular dependency modules
- Fixed import filtering logic in wrapper.rs to better handle unused imports

## Test Results

- ✅ Rich ecosystem test passes
- ✅ All unit tests pass
- ⚠️ Some snapshot tests updated (expected - changes in how `globals()` is handled in circular deps)
- ⚠️ One test needs investigation (side_effect_preservation)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Bundling and wrapper/module transforms now detect and respect circular dependencies, improving correctness for cyclic graphs.
  - Globals handling in wrapper modules no longer recurses into function/class bodies, preventing incorrect transformations.

- Refactor
  - Unused-symbol and import handling for wrappers refined; function-context expression generation simplified.
  - Per-function symbol-usage is threaded through transforms to reduce redundant work and unnecessary rewrites.

- Chores
  - Improved diagnostics and debug logging for wrapper/circular-dependency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->