### PR TITLE
ci: replace rust-code-analysis with mehen action

### DIFF
--- a/.agents/skills/pr-comment/SKILL.md
+++ b/.agents/skills/pr-comment/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: pr-comment
+description: handling GitHub PR comments with proper replies
+argument-hint: comment link (e.g. https://github.com/wharflab/tally/pull/134#discussion_r2815672223)
+---
+
+# PR Comment Handler
+
+You are handling a GitHub PR review comment. Follow this procedure exactly:
+
+## Step 1: Parse the URL
+
+The user will provide a URL in this format:
+
+```text
+https://github.com/<owner>/<repo>/pull/<PR_NUMBER>#discussion_r<COMMENT_ID>
+```
+
+Extract:
+
+- `owner` and `repo` from the URL
+- `PR_NUMBER` - digits between `/pull/` and `#`
+- `COMMENT_ID` - digits after `discussion_r`
+
+## Step 2: Fetch Comment Details
+
+Use this command to fetch the comment:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/comments/<COMMENT_ID> \
+  --jq '
+"id:         \(.id)
+pr_number:   \(.pull_request_url | split("/") | last)
+author:      \(.user.login)
+created_at:  \(.created_at)
+file:        \(.path)
+line:        \(.start_line // .line)
+--- BEGIN_BODY ---
+\(.body)
+--- END_BODY ---"'
+```
+
+Display this information to the user.
+
+## Step 3: Apply ALL Suggestions
+
+**CRITICAL RULES:**
+
+- Verify each finding against the current code and only fix it if confirmed by code.
+- Ideally, start with adding a regression test if comment is about a potential bug
+- If user is giving you a link to "nitpicks" comment that means it is MANDATORY to fix in this PR
+- NO TODOs, NO placeholders, NO deferred fixes, NO linting disabling comments
+- Read the relevant files and make the changes requested
+- If the comment references multiple issues, fix all of them
+- If unclear, make your best judgment and proceed
+
+## Step 4: Commit and Push
+
+After applying all changes:
+
+1. Stage the changed files
+2. Create a commit with this format:
+
+   ```text
+   fix: address PR review comment
+
+   <brief description of what was changed>
+
+   Addresses: https://github.com/<owner>/<repo>/pull/<PR_NUMBER>#discussion_r<COMMENT_ID>
+   ```
+
+3. Push to the current branch
+4. Capture the short commit SHA (7 chars)
+
+## Step 5: Reply to Comment
+
+Reply DIRECTLY to the specific comment (not a new review, not a top-level comment):
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments/<COMMENT_ID>/replies \
+  -X POST -f body='✅ Addressed in <short-sha>. Thanks @<author>!' --jq '"💬 Replied to comment \(.in_reply_to_id)"'
+```
+
+Replace:
+
+- `<short-sha>` with the 7-character commit hash
+- `<author>` with the comment author’s username, dropping `[bot]` suffix if any
+
+IMPORTANT: the above API WORKS! If you are getting 404 or similar error - verify that you've
+built the URL correctly, don't fallback to post a generic comment on PR!
+
+## Output Format
+
+Show the user:
+
+1. ✅ Comment details fetched
+2. ✅ Changes applied to: [list of files]
+3. ✅ Committed as: [short-sha]
+4. ✅ Replied to comment: [comment URL]
+
+## Error Handling
+
+If any step fails:
+
+- Report the exact error
+- Show what was completed
+- Ask user how to proceed

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+GH_PAGER = "cat"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - '**/*.rs'
+      - .github/workflows/lint.yml
 
 permissions:
   contents: read
@@ -48,7 +49,8 @@ jobs:
 
       # Generate clippy JSON report for SonarQube
       - name: Generate Clippy report for SonarQube
-        run: cargo clippy --workspace --all-targets --all-features --locked --message-format=json > target/clippy.json || true
+        run: cargo clippy --workspace --all-targets --all-features --locked
+          --message-format=json > target/clippy.json || true
 
       - run: cargo fmt --all --check
 
@@ -62,7 +64,7 @@ jobs:
           RUSTFLAGS: ''
 
       - name: Publish mehen metrics
-        uses: ophidiarium/mehen@codex/github-action-metrics
+        uses: ophidiarium/mehen@v0
         with:
           install-method: cargo
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - "**/*.rs"
+      - '**/*.rs'
 
 permissions:
+  contents: read
   pull-requests: write
   issues: write
 
@@ -17,7 +18,7 @@ name: Code Quality Checks
 
 # Make sure CI fails on all warnings, including Clippy lints
 env:
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: '-Dwarnings'
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
 
@@ -58,171 +59,14 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          RUSTFLAGS: ""
+          RUSTFLAGS: ''
 
-      # Install rust-code-analysis
-      - name: Install rust-code-analysis
-        env:
-          RCA_LINK: https://github.com/mozilla/rust-code-analysis/releases/download
-          RCA_VERSION: v0.0.25
-        run: |
-          mkdir -p $HOME/.local/bin
-          curl -L "$RCA_LINK/$RCA_VERSION/rust-code-analysis-linux-cli-x86_64.tar.gz" |
-          tar xz -C $HOME/.local/bin
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      # Prepare output directory for rust-code-analysis
-      - name: Prepare rust-code-analysis output dir
-        run: mkdir -p $HOME/rca-json
-
-      # Run rust-code-analysis on PR-diff files
-      - name: Run rust-code-analysis on PR-diff
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          rust-code-analysis-cli --metrics -O json --pr -o "$HOME/rca-json" -p crates/cribo/src
-
-      # Run rust-code-analysis on all files (push to main)
-      - name: Run rust-code-analysis on all files
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          rust-code-analysis-cli --metrics -O json -o "$HOME/rca-json" -p crates/cribo/src
-
-      - name: Upload rust-code-analysis json
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Publish mehen metrics
+        uses: ophidiarium/mehen@codex/github-action-metrics
         with:
-          name: rca-json-ubuntu
-          path: ~/rca-json
-
-      # Generate baseline rust-code-analysis metrics from main branch
-      - name: Prepare baseline rust-code-analysis output dir
-        if: ${{ github.event_name == 'pull_request' }}
-        run: mkdir -p $HOME/rca-json-base
-      - name: Checkout main branch for baseline
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: main
-          path: main
-      - name: Run rust-code-analysis on main branch
-        if: ${{ github.event_name == 'pull_request' }}
-        working-directory: main
-        run: |
-          # Run baseline scan within main checkout, scanning same relative path as PR
-          rust-code-analysis-cli --metrics -O json -o "$HOME/rca-json-base" -p crates/cribo/src
-
-      # Comment rust-code-analysis metrics on pull requests with comparison
-      - name: Comment rust-code-analysis metrics on PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
+          install-method: cargo
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const prDir = `${process.env.HOME}/rca-json`;
-            const baseDir = `${process.env.HOME}/rca-json-base`;
-            // Repo context for links
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const ref = context.payload.pull_request.head.sha;
-            // Fetch list of changed files in this PR
-            const changedFilesList = await github.paginate(
-              github.rest.pulls.listFiles,
-              { owner, repo, pull_number: context.issue.number }
-            );
-            const changedFiles = new Set(changedFilesList.map(f => f.filename));
-            let rows = [];
-            const collectFiles = (d) => fs.readdirSync(d, { withFileTypes: true }).flatMap(dirent => {
-              const full = `${d}/${dirent.name}`;
-              return dirent.isDirectory() ? collectFiles(full) : [full];
-            });
-            // Only include metrics for files changed in this PR
-            let prFiles = collectFiles(prDir).filter(f => f.endsWith('.json'));
-            prFiles = prFiles.filter(fullPath => {
-              const rel = fullPath.slice(prDir.length + 1).replace(/\.json$/, '');
-              return changedFiles.has(rel);
-            });
-            prFiles.forEach(fullPath => {
-              const rel = fullPath.slice(prDir.length + 1).replace(/\.json$/, '');
-              // Build GitHub link for file
-              const fileLink = `[${rel}](https://github.com/${owner}/${repo}/blob/${ref}/${rel})`;
-              // PR metrics
-              const prRaw = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-              const prItems = Array.isArray(prRaw) ? prRaw : [prRaw];
-              const prCount = prItems.length || 1;
-              const prCyclo = prItems.reduce((s,o)=>s+o.metrics.cyclomatic.sum,0)/prCount;
-              const prCog   = prItems.reduce((s,o)=>s+o.metrics.cognitive.sum,0)/prCount;
-              const prFunc  = prItems.reduce((s,o)=>s+o.metrics.nom.functions,0);
-              const prLloc  = prItems.reduce((s,o)=>s+o.metrics.loc.lloc,0);
-              // Baseline metrics (if exists)
-              let baseCyclo = prCyclo, baseCog = prCog, baseFunc = prFunc, baseLloc = prLloc;
-              const basePath = `${baseDir}/${rel}.json`;
-              if (fs.existsSync(basePath)) {
-                const baseRaw = JSON.parse(fs.readFileSync(basePath,'utf8'));
-                const baseItems = Array.isArray(baseRaw)?baseRaw:[baseRaw];
-                const baseCount = baseItems.length||1;
-                baseCyclo = baseItems.reduce((s,o)=>s+o.metrics.cyclomatic.sum,0)/baseCount;
-                baseCog   = baseItems.reduce((s,o)=>s+o.metrics.cognitive.sum,0)/baseCount;
-                baseFunc  = baseItems.reduce((s,o)=>s+o.metrics.nom.functions,0);
-                baseLloc  = baseItems.reduce((s,o)=>s+o.metrics.loc.lloc,0);
-              }
-              // Compute diffs and emojis
-              const diffFunc = prFunc - baseFunc;
-              const diffCyclo = (prCyclo - baseCyclo).toFixed(1);
-              const diffCog = (prCog - baseCog).toFixed(1);
-              const diffLloc = prLloc - baseLloc;
-              const emoji = d => d>0? '🔴': d<0? '🟢':'⚪';
-              // Push row showing PR vs main values with emoji
-              // Determine cell content: only emoji if unchanged, else "current (main) emoji"
-              const funcsCell = prFunc === baseFunc
-                ? `${prFunc.toFixed(0)} ${emoji(0)}`
-                : `${prFunc} (main: ${baseFunc}) ${emoji(diffFunc)}`;
-              const cycloCell = prCyclo === baseCyclo
-                ? `${prCyclo.toFixed(0)} ${emoji(0)}`
-                : `${prCyclo.toFixed(0)} (main: ${baseCyclo.toFixed(0)}) ${emoji(diffCyclo)}`;
-              const cogCell = prCog === baseCog
-                ? `${prCog.toFixed(0)} ${emoji(0)}`
-                : `${prCog.toFixed(0)} (main: ${baseCog.toFixed(0)}) ${emoji(diffCog)}`;
-              const llocCell = prLloc === baseLloc
-                ? `${prLloc} ${emoji(0)}`
-                : `${prLloc} (main: ${baseLloc}) ${emoji(diffLloc)}`;
-              // Include numeric funcsVal for sorting, and formatted cells for display
-              rows.push({ file: fileLink, funcsVal: prFunc, funcs: funcsCell, cyclo: cycloCell, cog: cogCell, lloc: llocCell });
-            });
-            // Sort rows by numeric funcsVal descending
-            rows.sort((a, b) => {
-              const diff = b.funcsVal - a.funcsVal;
-              return diff !== 0 ? diff : a.file.localeCompare(b.file);
-            });
-            // Build markdown comparison table showing current vs main
-            const commentTitle = '## [Rust-Code-Analysis](https://mozilla.github.io/rust-code-analysis/) Summary';
-            let body = commentTitle + ' (this PR vs `main`)\n\n';
-            body += '| File | Functions | [Cyclomatic](https://en.wikipedia.org/wiki/Cyclomatic_complexity) | [Cognitive](https://www.sonarsource.com/blog/cognitive-complexity-because-testability-understandability/) | LLOC |\n';
-            body += '|---|---:|---:|---:|---:|\n';
-            rows.forEach(r => body += `| ${r.file} | ${r.funcs} | ${r.cyclo} | ${r.cog} | ${r.lloc} |\n`);
-            // find existing summary comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const prev = comments.find(c => c.body.startsWith(commentTitle));
-            if (prev) {
-              // update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: prev.id,
-                body,
-              });
-            } else {
-              // create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          paths: crates/cribo/src
 
       - name: Cargo Machete
         uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2


### PR DESCRIPTION
## Summary
- replace the inline rust-code-analysis install/run/comment workflow with the reusable mehen metrics action
- keep the existing Cribo metrics scope at `crates/cribo/src`
- add explicit `contents: read` permission needed by checkout/action execution

## Notes
- This temporarily points to `ophidiarium/mehen@codex/github-action-metrics`, introduced in ophidiarium/mehen#55. Once mehen publishes `v1`, this can move to `ophidiarium/mehen@v1`.

## Verification
- `actionlint .github/workflows/lint.yml`
- `git diff --check`
- local `mehen diff --output-format json --from origin/main --to HEAD --paths crates/cribo/src` smoke test returned `[]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows for improved code quality analysis
  * Enhanced GitHub CLI configuration for optimized output handling
  * Introduced streamlined PR comment processing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->