### PR TITLE
[codex] consolidate module identity and lifecycle state

### DIFF
--- a/crates/cribo/benches/bundling.rs
+++ b/crates/cribo/benches/bundling.rs
@@ -129,30 +129,23 @@ fn benchmark_module_resolution(c: &mut Criterion) {
 
 /// Benchmark dependency graph construction
 fn benchmark_dependency_graph(c: &mut Criterion) {
-    use std::path::PathBuf;
+    use std::path::Path;
 
-    use cribo::{dependency_graph::DependencyGraph, resolver::ModuleId};
+    use cribo::{config::Config, dependency_graph::DependencyGraph, resolver::ModuleResolver};
+
+    let resolver = ModuleResolver::new(Config::default());
+    let main_id = resolver.register_module("main", Path::new("main.py"));
+    let utils_id = resolver.register_module("utils.helpers", Path::new("utils/helpers.py"));
+    let models_id = resolver.register_module("models.user", Path::new("models/user.py"));
 
     c.bench_function("build_dependency_graph", |b| {
         b.iter(|| {
             let mut graph = DependencyGraph::new();
 
             // Add modules
-            let main_id = graph.add_module(
-                ModuleId::new(0),
-                "main".to_owned(),
-                &PathBuf::from("main.py"),
-            );
-            let utils_id = graph.add_module(
-                ModuleId::new(1),
-                "utils.helpers".to_owned(),
-                &PathBuf::from("utils/helpers.py"),
-            );
-            let models_id = graph.add_module(
-                ModuleId::new(2),
-                "models.user".to_owned(),
-                &PathBuf::from("models/user.py"),
-            );
+            graph.add_module(main_id, &resolver);
+            graph.add_module(utils_id, &resolver);
+            graph.add_module(models_id, &resolver);
 
             // Add dependencies - main depends on utils and models
             graph.add_module_dependency(main_id, utils_id);

--- a/crates/cribo/src/code_generator/bundler/imports.rs
+++ b/crates/cribo/src/code_generator/bundler/imports.rs
@@ -249,7 +249,10 @@ impl Bundler<'_> {
     ) -> Option<(String, String)> {
         // We need to check if this symbol is imported from a submodule and re-exported
         let graph = self.graph?;
-        let module = graph.get_module_by_name(module_name)?;
+        let module = self
+            .resolver
+            .get_module_id_by_name(module_name)
+            .and_then(|id| graph.get_module(id))?;
 
         for item_data in module.items.values() {
             let crate::dependency_graph::ItemType::FromImport {

--- a/crates/cribo/src/code_generator/bundler/mod.rs
+++ b/crates/cribo/src/code_generator/bundler/mod.rs
@@ -60,8 +60,6 @@ pub(crate) struct Bundler<'a> {
     /// Modules that are imported as namespaces (e.g., from package import module)
     /// Maps module ID to set of importing module IDs
     pub(crate) namespace_imported_modules: FxIndexMap<ModuleId, FxIndexSet<ModuleId>>,
-    /// Reference to the central module registry
-    pub(crate) module_info_registry: Option<&'a crate::orchestrator::ModuleRegistry>,
     /// Reference to the module resolver
     pub(crate) resolver: &'a ModuleResolver,
     /// Modules that are part of circular dependencies (may be pruned for entry package)
@@ -324,10 +322,7 @@ impl<'a> Bundler<'a> {
     }
 
     /// Create a new bundler instance
-    pub(crate) fn new(
-        module_info_registry: Option<&'a crate::orchestrator::ModuleRegistry>,
-        resolver: &'a ModuleResolver,
-    ) -> Self {
+    pub(crate) fn new(resolver: &'a ModuleResolver) -> Self {
         Self {
             module_synthetic_names: FxIndexMap::default(),
             module_init_functions: FxIndexMap::default(),
@@ -341,7 +336,6 @@ impl<'a> Bundler<'a> {
             module_exports: FxIndexMap::default(),
             semantic_exports: FxIndexMap::default(),
             namespace_imported_modules: FxIndexMap::default(),
-            module_info_registry,
             resolver,
             circular_modules: FxIndexSet::default(),
             all_circular_modules: FxIndexSet::default(),

--- a/crates/cribo/src/code_generator/bundler/symbols.rs
+++ b/crates/cribo/src/code_generator/bundler/symbols.rs
@@ -1067,7 +1067,7 @@ else:
     #[test]
     fn test_reorder_statements_for_circular_module_preserves_entry_order() {
         let resolver = ModuleResolver::new(Config::default());
-        let mut bundler = Bundler::new(None, &resolver);
+        let mut bundler = Bundler::new(&resolver);
         bundler.entry_module_name = "entry_module".to_owned();
 
         let statements = parse_assignment_statements("first = 1\nsecond = 2\nthird = 3\n");
@@ -1081,7 +1081,7 @@ else:
     #[test]
     fn test_reorder_statements_for_circular_module_preserves_non_entry_order() {
         let resolver = ModuleResolver::new(Config::default());
-        let mut bundler = Bundler::new(None, &resolver);
+        let mut bundler = Bundler::new(&resolver);
         bundler.entry_module_name = "entry_module".to_owned();
 
         let statements = parse_assignment_statements("first = 1\nsecond = 2\nthird = 3\n");

--- a/crates/cribo/src/code_generator/import_deduplicator.rs
+++ b/crates/cribo/src/code_generator/import_deduplicator.rs
@@ -300,7 +300,7 @@ pub(super) fn trim_unused_imports_from_modules(
                                     let potential_submodule =
                                         format!("{resolved_from_module}.{imported_name}");
                                     // Check if this module exists in the graph
-                                    graph.get_module_by_name(&potential_submodule).is_some()
+                                    shaker.get_graph_module_id(&potential_submodule).is_some()
                                 };
 
                                 // If this is a submodule import, check if the submodule has side
@@ -315,9 +315,8 @@ pub(super) fn trim_unused_imports_from_modules(
                                     // Check if the submodule has side effects or symbols that
                                     // survived Even if no
                                     // symbols survived, if it has side effects, we need to keep it
-                                    let has_side_effects = graph
-                                        .get_module_by_name(&submodule_name)
-                                        .map(|m| m.module_id)
+                                    let has_side_effects = shaker
+                                        .get_graph_module_id(&submodule_name)
                                         .is_some_and(|id| shaker.module_has_side_effects(id));
                                     let has_used_symbols = !shaker
                                         .get_used_symbols_for_module(&submodule_name)
@@ -414,9 +413,8 @@ pub(super) fn trim_unused_imports_from_modules(
                             // where a wrapper module with side effects is imported
                             // but not directly used (e.g., import mypackage where mypackage has
                             // print statements)
-                            let module_has_side_effects = graph
-                                .get_module_by_name(module)
-                                .map(|m| m.module_id)
+                            let module_has_side_effects = shaker
+                                .get_graph_module_id(module)
                                 .is_some_and(|id| shaker.module_has_side_effects(id));
                             if module_has_side_effects {
                                 log::debug!(

--- a/crates/cribo/src/code_generator/import_deduplicator.rs
+++ b/crates/cribo/src/code_generator/import_deduplicator.rs
@@ -296,18 +296,13 @@ pub(super) fn trim_unused_imports_from_modules(
                                 // Check if this import is actually importing a submodule
                                 // For example, "from mypackage import utils" where utils is
                                 // mypackage.utils
-                                let is_submodule_import = {
-                                    let potential_submodule =
-                                        format!("{resolved_from_module}.{imported_name}");
-                                    // Check if this module exists in the graph
-                                    shaker.get_graph_module_id(&potential_submodule).is_some()
-                                };
+                                let submodule_name =
+                                    format!("{resolved_from_module}.{imported_name}");
+                                let submodule_id = shaker.get_graph_module_id(&submodule_name);
 
                                 // If this is a submodule import, check if the submodule has side
                                 // effects or is otherwise needed
-                                let submodule_needed = if is_submodule_import {
-                                    let submodule_name =
-                                        format!("{resolved_from_module}.{imported_name}");
+                                let submodule_needed = submodule_id.is_some_and(|submodule_id| {
                                     log::debug!(
                                         "Import '{local_name}' is a submodule import for \
                                          '{submodule_name}'"
@@ -315,9 +310,8 @@ pub(super) fn trim_unused_imports_from_modules(
                                     // Check if the submodule has side effects or symbols that
                                     // survived Even if no
                                     // symbols survived, if it has side effects, we need to keep it
-                                    let has_side_effects = shaker
-                                        .get_graph_module_id(&submodule_name)
-                                        .is_some_and(|id| shaker.module_has_side_effects(id));
+                                    let has_side_effects =
+                                        shaker.module_has_side_effects(submodule_id);
                                     let has_used_symbols = !shaker
                                         .get_used_symbols_for_module(&submodule_name)
                                         .is_empty();
@@ -328,9 +322,7 @@ pub(super) fn trim_unused_imports_from_modules(
                                     );
 
                                     has_side_effects || has_used_symbols
-                                } else {
-                                    false
-                                };
+                                });
 
                                 // Check if this import is only used by symbols that were
                                 // tree-shaken

--- a/crates/cribo/src/code_generator/import_transformer/handlers/inlined.rs
+++ b/crates/cribo/src/code_generator/import_transformer/handlers/inlined.rs
@@ -676,7 +676,6 @@ impl InlinedHandler {
 
         let params = crate::code_generator::module_registry::InlinedImportParams {
             symbol_renames,
-            module_registry: bundler.module_info_registry,
             inlined_modules: &bundler.inlined_modules,
             bundled_modules: &bundler.bundled_modules,
             resolver: bundler.resolver,

--- a/crates/cribo/src/code_generator/import_transformer/handlers/submodule.rs
+++ b/crates/cribo/src/code_generator/import_transformer/handlers/submodule.rs
@@ -54,7 +54,7 @@ impl SubmoduleHandler {
             {
                 crate::code_generator::module_registry::is_wrapper_submodule(
                     submodule_id,
-                    transformer.state.bundler.module_info_registry,
+                    &transformer.state.bundler.bundled_modules,
                     &transformer.state.bundler.inlined_modules,
                 )
             } else {

--- a/crates/cribo/src/code_generator/import_transformer/mod.rs
+++ b/crates/cribo/src/code_generator/import_transformer/mod.rs
@@ -1472,9 +1472,7 @@ fn rewrite_import_with_renames(
                 // Module uses wrapper approach - need to initialize it now
 
                 // First, ensure the module is initialized
-                if let Some(module_id) = bundler.get_module_id(module_name) {
-                    result_stmts.extend(bundler.create_module_initialization_for_import(module_id));
-                }
+                result_stmts.extend(bundler.create_module_initialization_for_import(module_id));
 
                 // Then create assignment if needed (skip self-assignments)
                 if target_name.as_str() != module_name {

--- a/crates/cribo/src/code_generator/import_transformer/mod.rs
+++ b/crates/cribo/src/code_generator/import_transformer/mod.rs
@@ -377,12 +377,6 @@ impl<'a> RecursiveImportTransformer<'a> {
             .get_module_id(&full_submodule_path)
             .is_some_and(|id| {
                 self.state.bundler.bundled_modules.contains(&id)
-                    || self
-                        .state
-                        .bundler
-                        .module_info_registry
-                        .as_ref()
-                        .is_some_and(|reg| reg.contains_module(id))
                     || self.state.bundler.inlined_modules.contains(&id)
             });
         if is_actually_a_module {
@@ -1435,25 +1429,7 @@ fn rewrite_import_with_renames(
 
             let target_name = alias.asname.as_ref().unwrap_or(&alias.name);
 
-            if bundler
-                .module_info_registry
-                .is_some_and(|reg| reg.contains_module(module_id))
-            {
-                // Module uses wrapper approach - need to initialize it now
-
-                // First, ensure the module is initialized
-                if let Some(module_id) = bundler.get_module_id(module_name) {
-                    result_stmts.extend(bundler.create_module_initialization_for_import(module_id));
-                }
-
-                // Then create assignment if needed (skip self-assignments)
-                if target_name.as_str() != module_name {
-                    result_stmts.push(
-                        bundler
-                            .create_module_reference_assignment(target_name.as_str(), module_name),
-                    );
-                }
-            } else {
+            if bundler.inlined_modules.contains(&module_id) {
                 // Module was inlined - create a namespace object
 
                 // Create namespace object with the module's exports
@@ -1491,6 +1467,21 @@ fn rewrite_import_with_renames(
                     );
                     result_stmts.extend(new_stmts);
                     populated_modules.insert(module_id);
+                }
+            } else {
+                // Module uses wrapper approach - need to initialize it now
+
+                // First, ensure the module is initialized
+                if let Some(module_id) = bundler.get_module_id(module_name) {
+                    result_stmts.extend(bundler.create_module_initialization_for_import(module_id));
+                }
+
+                // Then create assignment if needed (skip self-assignments)
+                if target_name.as_str() != module_name {
+                    result_stmts.push(
+                        bundler
+                            .create_module_reference_assignment(target_name.as_str(), module_name),
+                    );
                 }
             }
         }

--- a/crates/cribo/src/code_generator/init_function/body_preparation.rs
+++ b/crates/cribo/src/code_generator/init_function/body_preparation.rs
@@ -161,25 +161,7 @@ impl BodyPreparationPhase {
             ctx.module_name
         );
 
-        // Use the central module registry for fast, reliable lookup
-        let module_id = bundler
-            .module_info_registry
-            .and_then(|registry| {
-                let id = registry.get_id_by_name(ctx.module_name);
-                if id.is_some() {
-                    debug!(
-                        "Found module ID for '{}' using module registry",
-                        ctx.module_name
-                    );
-                } else {
-                    debug!("Module '{}' not found in module registry", ctx.module_name);
-                }
-                id
-            })
-            .or_else(|| {
-                log::warn!("No module registry available for module ID lookup");
-                None
-            });
+        let module_id = bundler.resolver.get_module_id_by_name(ctx.module_name);
 
         if let Some(module_id) = module_id {
             if let Some(module_info) = conflict_resolver.get_module_info(module_id) {

--- a/crates/cribo/src/code_generator/module_registry.rs
+++ b/crates/cribo/src/code_generator/module_registry.rs
@@ -216,7 +216,6 @@ pub(crate) fn initialize_submodule_if_needed(
 /// Parameters for creating assignments for inlined imports
 pub(crate) struct InlinedImportParams<'a> {
     pub symbol_renames: &'a FxIndexMap<crate::resolver::ModuleId, FxIndexMap<String, String>>,
-    pub module_registry: Option<&'a crate::orchestrator::ModuleRegistry>,
     pub inlined_modules: &'a FxIndexSet<crate::resolver::ModuleId>,
     pub bundled_modules: &'a FxIndexSet<crate::resolver::ModuleId>,
     pub resolver: &'a crate::resolver::ModuleResolver,
@@ -252,9 +251,8 @@ pub(crate) fn create_assignments_for_inlined_imports(
         // Check if this is a module import
         // First check if it's a wrapped module
         if let Some(module_id) = params.resolver.get_module_id_by_name(&full_module_path) {
-            if params
-                .module_registry
-                .is_some_and(|reg| reg.contains_module(module_id))
+            if params.bundled_modules.contains(&module_id)
+                && !params.inlined_modules.contains(&module_id)
             {
                 // Skip wrapped modules - they will be handled as deferred imports
                 log::debug!("Module '{full_module_path}' is a wrapped module, deferring import");
@@ -463,14 +461,12 @@ pub(crate) fn register_module(
 
 /// Check if a module is a wrapper submodule (not inlined)
 ///
-/// A module is considered a wrapper submodule if:
-/// - It exists in the module registry (meaning it has an init function)
-/// - It is NOT in the inlined modules set
+/// A module is considered a wrapper submodule when it participates in the
+/// bundle but is not currently classified as inlined.
 pub(crate) fn is_wrapper_submodule(
     module_id: crate::resolver::ModuleId,
-    module_info_registry: Option<&crate::orchestrator::ModuleRegistry>,
+    bundled_modules: &FxIndexSet<crate::resolver::ModuleId>,
     inlined_modules: &FxIndexSet<crate::resolver::ModuleId>,
 ) -> bool {
-    module_info_registry.is_some_and(|reg| reg.contains_module(module_id))
-        && !inlined_modules.contains(&module_id)
+    bundled_modules.contains(&module_id) && !inlined_modules.contains(&module_id)
 }

--- a/crates/cribo/src/dependency_graph.rs
+++ b/crates/cribo/src/dependency_graph.rs
@@ -1,5 +1,3 @@
-use std::path::{Path, PathBuf};
-
 /// `DependencyGraph`: Advanced dependency graph implementation for Python bundling
 ///
 /// This module provides a sophisticated dependency tracking system that combines:
@@ -21,7 +19,7 @@ use petgraph::{
 };
 
 use crate::{
-    resolver::ModuleId,
+    resolver::{ModuleId, ModuleResolver},
     types::{FxIndexMap, FxIndexSet},
 };
 
@@ -407,24 +405,10 @@ impl ModuleDepGraph {
 pub struct DependencyGraph {
     /// All modules in the graph
     pub(crate) modules: FxIndexMap<ModuleId, ModuleDepGraph>,
-    /// Module name to ID mapping
-    pub(crate) module_names: FxIndexMap<String, ModuleId>,
-    /// Module path to ID mapping
-    pub(crate) module_paths: FxIndexMap<PathBuf, ModuleId>,
     /// Petgraph for efficient algorithms (inspired by Mako)
     graph: DiGraph<ModuleId, ()>,
     /// Node index mapping
     node_indices: FxIndexMap<ModuleId, NodeIndex>,
-
-    // Fields for file-based deduplication
-    /// Track canonical paths for each module
-    module_canonical_paths: FxIndexMap<ModuleId, PathBuf>,
-    /// Track all import names that resolve to each canonical file
-    /// This includes regular imports AND static importlib calls
-    file_to_import_names: FxIndexMap<PathBuf, FxIndexSet<String>>,
-    /// Track the primary module ID for each file
-    /// (The first import name discovered for this file)
-    file_primary_module: FxIndexMap<PathBuf, (String, ModuleId)>,
     /// Track modules whose __all__ attribute is accessed
     /// Maps (`accessing_module_id`, `accessed_module_id`) for __all__ access tracking to prevent
     /// alias collisions
@@ -437,91 +421,30 @@ impl DependencyGraph {
     pub fn new() -> Self {
         Self {
             modules: FxIndexMap::default(),
-            module_names: FxIndexMap::default(),
-            module_paths: FxIndexMap::default(),
             graph: DiGraph::new(),
             node_indices: FxIndexMap::default(),
-            module_canonical_paths: FxIndexMap::default(),
-            file_to_import_names: FxIndexMap::default(),
-            file_primary_module: FxIndexMap::default(),
             modules_accessing_all: FxIndexSet::default(),
         }
     }
 
     /// Add a module to the graph with a pre-assigned `ModuleId` from the resolver
     #[allow(unreachable_pub)]
-    pub fn add_module(&mut self, id: ModuleId, name: String, path: &Path) -> ModuleId {
-        // Always work with canonical paths
-        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_owned());
-
-        // Check if this exact import name already exists
-        if let Some(&existing_id) = self.module_names.get(&name) {
-            // Verify it's the same file
-            if let Some(existing_canonical) = self.module_canonical_paths.get(&existing_id) {
-                if existing_canonical == &canonical_path {
-                    // Same import name, same file - track and reuse
-                    self.file_to_import_names
-                        .entry(canonical_path)
-                        .or_default()
-                        .insert(name.clone());
-                    return existing_id;
-                }
-                // Same import name but different files: reuse existing mapping deterministically.
-                // Prevents alias flapping and preserves previously built edges.
-                log::warn!(
-                    "Import name '{name}' refers to different files: {} and {}. Reusing existing \
-                     ModuleId {} to keep mapping stable.",
-                    existing_canonical.display(),
-                    canonical_path.display(),
-                    existing_id.as_u32()
-                );
-                return existing_id;
-            }
+    pub fn add_module(&mut self, id: ModuleId, resolver: &ModuleResolver) -> ModuleId {
+        if self.modules.contains_key(&id) {
+            return id;
         }
 
-        // Track this import name for the file
-        self.file_to_import_names
-            .entry(canonical_path.clone())
-            .or_default()
-            .insert(name.clone());
-
-        // Check if this file already has a primary module
-        if let Some((primary_name, primary_id)) = self.file_primary_module.get(&canonical_path) {
-            log::info!(
-                "File {} already imported as '{primary_name}', reusing ModuleId for import name \
-                 '{name}'",
-                canonical_path.display()
-            );
-
-            // IMPORTANT: Return the SAME ModuleId for the same physical file
-            // This ensures circular dependency detection and all other processing
-            // operates on physical files, not module names
-            self.module_names.insert(name, *primary_id);
-
-            return *primary_id;
-        }
-
-        // Use the pre-assigned ID from the resolver
-        // The resolver guarantees that the entry module gets ID 0
-
-        // Create module
+        let name = resolver
+            .get_module_name(id)
+            .expect("Dependency graph modules must be registered with the resolver");
         let module_graph = ModuleDepGraph::new(id, name.clone());
         self.modules.insert(id, module_graph);
-        self.module_names.insert(name.clone(), id);
-        self.module_paths.insert(canonical_path.clone(), id);
-        self.module_canonical_paths
-            .insert(id, canonical_path.clone());
-        self.file_primary_module
-            .insert(canonical_path.clone(), (name.clone(), id));
 
         // Add to petgraph
         let node_idx = self.graph.add_node(id);
         self.node_indices.insert(id, node_idx);
 
-        log::debug!(
-            "Registered module '{name}' as primary for file {}",
-            canonical_path.display()
-        );
+        log::debug!("Added resolver module '{name}' ({id}) to dependency graph");
 
         id
     }
@@ -531,20 +454,9 @@ impl DependencyGraph {
         self.modules.get(&id)
     }
 
-    /// Get a module by name (for compatibility during migration)
-    pub(crate) fn get_module_by_name(&self, name: &str) -> Option<&ModuleDepGraph> {
-        self.module_names
-            .get(name)
-            .and_then(|&id| self.modules.get(&id))
-    }
-
-    /// Get a mutable module by name (for compatibility during migration)
-    pub(crate) fn get_module_by_name_mut(&mut self, name: &str) -> Option<&mut ModuleDepGraph> {
-        if let Some(&id) = self.module_names.get(name) {
-            self.modules.get_mut(&id)
-        } else {
-            None
-        }
+    /// Get a mutable module by ID.
+    pub(crate) fn get_module_mut(&mut self, id: ModuleId) -> Option<&mut ModuleDepGraph> {
+        self.modules.get_mut(&id)
     }
 
     /// Get modules that access __all__ attribute
@@ -761,22 +673,27 @@ impl Default for DependencyGraph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analyzers::types::{CircularDependencyType, ResolutionStrategy};
+    use crate::{
+        analyzers::types::{CircularDependencyType, ResolutionStrategy},
+        config::Config,
+    };
+
+    fn register_modules(names: &[&str]) -> (ModuleResolver, Vec<ModuleId>) {
+        let resolver = ModuleResolver::new(Config::default());
+        let ids = names
+            .iter()
+            .map(|name| resolver.register_module(name, std::path::Path::new(name)))
+            .collect();
+        (resolver, ids)
+    }
 
     #[test]
     fn test_basic_module_graph() {
         let mut graph = DependencyGraph::new();
+        let (resolver, ids) = register_modules(&["utils", "main"]);
 
-        let utils_id = graph.add_module(
-            ModuleId::new(0),
-            "utils".to_owned(),
-            &PathBuf::from("utils.py"),
-        );
-        let main_id = graph.add_module(
-            ModuleId::new(1),
-            "main".to_owned(),
-            &PathBuf::from("main.py"),
-        );
+        let utils_id = graph.add_module(ids[0], &resolver);
+        let main_id = graph.add_module(ids[1], &resolver);
 
         graph.add_module_dependency(main_id, utils_id);
 
@@ -790,23 +707,12 @@ mod tests {
     #[test]
     fn test_circular_dependency_detection() {
         let mut graph = DependencyGraph::new();
+        let (resolver, ids) = register_modules(&["module_a", "module_b", "module_c"]);
 
         // Create a three-module circular dependency: A -> B -> C -> A
-        let module_a = graph.add_module(
-            ModuleId::new(0),
-            "module_a".to_owned(),
-            &PathBuf::from("module_a.py"),
-        );
-        let module_b = graph.add_module(
-            ModuleId::new(1),
-            "module_b".to_owned(),
-            &PathBuf::from("module_b.py"),
-        );
-        let module_c = graph.add_module(
-            ModuleId::new(2),
-            "module_c".to_owned(),
-            &PathBuf::from("module_c.py"),
-        );
+        let module_a = graph.add_module(ids[0], &resolver);
+        let module_b = graph.add_module(ids[1], &resolver);
+        let module_c = graph.add_module(ids[2], &resolver);
 
         graph.add_module_dependency(module_a, module_b);
         graph.add_module_dependency(module_b, module_c);
@@ -831,17 +737,10 @@ mod tests {
         //           constants_b.py: `from constants_a import A_VALUE; B_VALUE = A_VALUE * 2`
         // Both modules read a cross-cycle import at module level → temporal paradox.
         let mut graph = DependencyGraph::new();
+        let (resolver, ids) = register_modules(&["mod_a", "mod_b"]);
 
-        let mod_a = graph.add_module(
-            ModuleId::new(0),
-            "mod_a".to_owned(),
-            &PathBuf::from("mod_a.py"),
-        );
-        let mod_b = graph.add_module(
-            ModuleId::new(1),
-            "mod_b".to_owned(),
-            &PathBuf::from("mod_b.py"),
-        );
+        let mod_a = graph.add_module(ids[0], &resolver);
+        let mod_b = graph.add_module(ids[1], &resolver);
 
         // mod_a: from mod_b import B_VALUE
         if let Some(module_a) = graph.modules.get_mut(&mod_a) {
@@ -948,12 +847,11 @@ mod tests {
     }
 
     #[test]
-    fn test_file_based_deduplication() {
+    fn test_duplicate_module_id_is_idempotent() {
         let mut graph = DependencyGraph::new();
+        let (resolver, ids) = register_modules(&["utils"]);
 
-        // Add a module with a canonical path
-        let path = PathBuf::from("src/utils.py");
-        let utils_id = graph.add_module(ModuleId::new(0), "utils".to_owned(), &path);
+        let utils_id = graph.add_module(ids[0], &resolver);
 
         // Add some items to the utils module
         let utils_module = graph
@@ -978,19 +876,15 @@ mod tests {
             containing_scope: None,
         });
 
-        // Add the same file with a different import name
-        // This should return the SAME ModuleId due to file-based deduplication
-        let alt_utils_id = graph.add_module(ModuleId::new(1), "src.utils".to_owned(), &path);
+        // Aliases are resolved before graph insertion, so adding the resolver's
+        // existing ID again must leave the graph unchanged.
+        let alt_utils_id = graph.add_module(utils_id, &resolver);
 
-        // Verify that both names map to the same ModuleId (file-based deduplication)
-        assert_eq!(utils_id, alt_utils_id, "Same file should get same ModuleId");
+        assert_eq!(utils_id, alt_utils_id);
+        assert_eq!(graph.modules.len(), 1);
 
         // Verify the module exists
         assert!(graph.modules.contains_key(&utils_id));
-
-        // Verify that both names are tracked
-        assert_eq!(graph.module_names.get("utils"), Some(&utils_id));
-        assert_eq!(graph.module_names.get("src.utils"), Some(&utils_id));
 
         // Get the module
         let utils_module = &graph.modules[&utils_id];

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -749,8 +749,8 @@ impl BundleOrchestrator {
         modules_to_process.push((ModuleId::ENTRY, entry_path));
         queued_modules.insert(ModuleId::ENTRY);
 
-        // Store module data for phase 2 including parsed AST
-        type DiscoveryData = (ModuleId, PathBuf, Vec<String>, ModModule, String); // (id, path, imports, ast, source) for discovery phase
+        // Store module data for phase 2, including the parse products.
+        type DiscoveryData = (ModuleId, PathBuf, Vec<String>, ProcessedModule);
         let mut discovered_modules: Vec<DiscoveryData> = Vec::new();
 
         // PHASE 1: Discover and collect all modules
@@ -787,14 +787,7 @@ impl BundleOrchestrator {
                 .collect();
             debug!("Extracted imports from {module_name}: {imports:?}");
 
-            // Store module data including parsed AST for later processing
-            discovered_modules.push((
-                module_id,
-                module_path.clone(),
-                imports.clone(),
-                processed.ast,
-                processed.source,
-            ));
+            discovered_modules.push((module_id, module_path.clone(), imports, processed));
             processed_modules.insert(module_id);
 
             // Find and queue first-party imports for discovery
@@ -827,15 +820,13 @@ impl BundleOrchestrator {
         // First, add all modules to the graph and run semantic analysis.
         let mut parsed_modules: Vec<ParsedModuleData> = Vec::new();
 
-        for (discovered_module_id, module_path, imports, _ast, _source) in discovered_modules {
+        for (module_id, module_path, imports, processed) in discovered_modules {
             let module_name = params
                 .resolver
-                .get_module_name(discovered_module_id)
-                .unwrap_or_else(|| format!("module_{}", discovered_module_id.as_u32()));
+                .get_module_name(module_id)
+                .unwrap_or_else(|| format!("module_{}", module_id.as_u32()));
             debug!("Phase 2: Processing module '{module_name}'");
 
-            let processed = self.process_module(&module_path, &module_name)?;
-            let module_id = discovered_module_id;
             params.graph.add_module(module_id, params.resolver);
             self.conflict_resolver
                 .analyze_module(module_id, &processed.ast, &module_path);
@@ -851,7 +842,7 @@ impl BundleOrchestrator {
             }
 
             // Store parsed module data for later use
-            parsed_modules.push((module_id, imports.clone(), processed.ast, processed.source));
+            parsed_modules.push((module_id, imports, processed.ast, processed.source));
         }
 
         info!("Added {} modules to graph", params.graph.modules.len());

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -31,88 +31,6 @@ use crate::{
 /// Static empty parsed module for creating Stylist instances
 static EMPTY_PARSED_MODULE: OnceLock<ruff_python_parser::Parsed<ModModule>> = OnceLock::new();
 
-/// Immutable module information stored in the registry
-#[derive(Debug, Clone)]
-pub(crate) struct ModuleInfo {
-    /// The unique module ID assigned by the dependency graph
-    pub id: ModuleId,
-    /// The canonical module name (e.g., "requests.compat")
-    pub canonical_name: String,
-    /// The resolved filesystem path
-    pub resolved_path: PathBuf,
-}
-
-/// Central registry for module information
-/// This is the single source of truth for module identity throughout the bundling process
-#[derive(Debug)]
-pub(crate) struct ModuleRegistry {
-    /// Map from `ModuleId` to complete module information
-    modules: FxIndexMap<ModuleId, ModuleInfo>,
-    /// Map from canonical name to `ModuleId` for fast lookups
-    name_to_id: FxIndexMap<String, ModuleId>,
-    /// Map from resolved path to `ModuleId` for fast lookups
-    path_to_id: FxIndexMap<PathBuf, ModuleId>,
-}
-
-impl Default for ModuleRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ModuleRegistry {
-    /// Create a new empty module registry
-    pub(crate) fn new() -> Self {
-        Self {
-            modules: FxIndexMap::default(),
-            name_to_id: FxIndexMap::default(),
-            path_to_id: FxIndexMap::default(),
-        }
-    }
-
-    /// Add a module to the registry
-    pub(crate) fn add_module(&mut self, info: ModuleInfo) {
-        let id = info.id;
-        let name = info.canonical_name.clone();
-        let path = info.resolved_path.clone();
-
-        // Check if module already exists
-        if let Some(existing) = self.modules.get(&id) {
-            // For the same ModuleId, we allow different canonical names
-            // (e.g., "__init__" and "yaml" for the same file)
-            // but the path must be the same
-            assert!(
-                existing.resolved_path == path,
-                "Attempting to register module {:?} with conflicting paths. Existing: {} at {}, \
-                 New: {} at {}",
-                id,
-                existing.canonical_name,
-                existing.resolved_path.display(),
-                name,
-                path.display()
-            );
-
-            // Add this new name as an alias for the same ModuleId
-            self.name_to_id.insert(name, id);
-            return; // Module already registered, just added new name mapping
-        }
-
-        self.name_to_id.insert(name, id);
-        self.path_to_id.insert(path, id);
-        self.modules.insert(id, info);
-    }
-
-    /// Get module ID by canonical name
-    pub(crate) fn get_id_by_name(&self, name: &str) -> Option<ModuleId> {
-        self.name_to_id.get(name).copied()
-    }
-
-    /// Check if a module exists by `ModuleId`
-    pub(crate) fn contains_module(&self, id: ModuleId) -> bool {
-        self.modules.contains_key(&id)
-    }
-}
-
 /// Get or create the empty parsed module for Stylist creation
 fn get_empty_parsed_module() -> &'static ruff_python_parser::Parsed<ModModule> {
     EMPTY_PARSED_MODULE
@@ -175,8 +93,6 @@ struct ProcessedModule {
     source: String,
     /// Shared module facts reused by discovery and later graph-driven analyses.
     facts: Arc<ModuleFacts>,
-    /// Module ID if already added to dependency graph
-    module_id: Option<ModuleId>,
 }
 
 /// Main orchestrator for bundling operations
@@ -186,8 +102,6 @@ struct ProcessedModule {
 pub struct BundleOrchestrator {
     config: Config,
     conflict_resolver: SymbolConflictResolver,
-    /// Central registry for module information
-    module_registry: ModuleRegistry,
     /// Cache of processed modules to ensure we only parse and transform once
     module_cache: std::sync::Mutex<FxIndexMap<PathBuf, ProcessedModule>>,
 }
@@ -198,7 +112,6 @@ impl BundleOrchestrator {
         Self {
             config,
             conflict_resolver: SymbolConflictResolver::new(),
-            module_registry: ModuleRegistry::new(),
             module_cache: std::sync::Mutex::new(FxIndexMap::default()),
         }
     }
@@ -209,16 +122,9 @@ impl BundleOrchestrator {
     /// Pipeline:
     /// 1. Check cache
     /// 2. Read file and parse
-    /// 3. Semantic analysis (on raw AST)
-    /// 4. Stdlib normalization (transforms AST)
-    /// 5. Cache result
-    fn process_module(
-        &mut self,
-        module_path: &Path,
-        module_name: &str,
-        graph: Option<&mut DependencyGraph>,
-        resolver: Option<&ModuleResolver>,
-    ) -> Result<ProcessedModule> {
+    /// 3. Derive reusable module facts
+    /// 4. Cache parse products
+    fn process_module(&self, module_path: &Path, module_name: &str) -> Result<ProcessedModule> {
         // Canonicalize path for consistent caching
         let canonical_path = module_path
             .canonicalize()
@@ -235,42 +141,10 @@ impl BundleOrchestrator {
 
         if let Some(cached) = cached_data {
             debug!("Using cached module: {module_name}");
-
-            // If graph is provided but cached module doesn't have module_id,
-            // we need to add it to the graph
-            let module_id = if let Some(graph) = graph {
-                if cached.module_id.is_none() {
-                    // Get or register module ID with resolver (required when graph is Some)
-                    let resolver = resolver.expect("Resolver must be provided when graph is Some");
-                    let module_id = resolver.register_module(module_name, module_path);
-
-                    graph.add_module(module_id, module_name.to_owned(), module_path);
-
-                    // Perform semantic analysis
-                    self.conflict_resolver
-                        .analyze_module(module_id, &cached.ast, &canonical_path);
-
-                    // Add to module registry
-                    let module_info = ModuleInfo {
-                        id: module_id,
-                        canonical_name: module_name.to_owned(),
-                        resolved_path: canonical_path,
-                    };
-                    self.module_registry.add_module(module_info);
-
-                    Some(module_id)
-                } else {
-                    cached.module_id
-                }
-            } else {
-                cached.module_id
-            };
-
             return Ok(ProcessedModule {
                 ast: cached.ast.clone(),
                 source: cached.source.clone(),
                 facts: Arc::clone(&cached.facts),
-                module_id,
             });
         }
 
@@ -290,37 +164,12 @@ impl BundleOrchestrator {
         let python_version = self.config.python_version().unwrap_or(10);
         let facts = Arc::new(ModuleFacts::from_ast(&ast, python_version)?);
 
-        // Step 2: Add to graph and perform semantic analysis (if graph provided)
-        let module_id = if let Some(graph) = graph {
-            // Get or register module ID with resolver (required when graph is Some)
-            let resolver = resolver.expect("Resolver must be provided when graph is Some");
-            let module_id = resolver.register_module(module_name, module_path);
-
-            graph.add_module(module_id, module_name.to_owned(), module_path);
-
-            // Semantic analysis on raw AST
-            self.conflict_resolver
-                .analyze_module(module_id, &ast, &canonical_path);
-
-            // Add to module registry
-            let module_info = ModuleInfo {
-                id: module_id,
-                canonical_name: module_name.to_owned(),
-                resolved_path: canonical_path.clone(),
-            };
-            self.module_registry.add_module(module_info);
-
-            Some(module_id)
-        } else {
-            None
-        };
-
-        // Step 3: Cache the result
+        // Step 2: Cache the parse products. Identity and graph lifecycle are owned by
+        // the resolver and dependency-graph build phase, respectively.
         let processed = ProcessedModule {
             ast: ast.clone(),
             source: source.clone(),
             facts: Arc::clone(&facts),
-            module_id,
         };
 
         {
@@ -331,12 +180,7 @@ impl BundleOrchestrator {
             cache.insert(canonical_path, processed);
         }
 
-        Ok(ProcessedModule {
-            ast,
-            source,
-            facts,
-            module_id,
-        })
+        Ok(ProcessedModule { ast, source, facts })
     }
 
     /// Format error message for unresolvable cycles
@@ -928,9 +772,8 @@ impl BundleOrchestrator {
                 continue;
             }
 
-            // Process module through the pipeline (parse, semantic analysis, normalization)
-            let processed =
-                self.process_module(&module_path, &module_name, None, Some(params.resolver))?;
+            // Parse the module and cache its reusable facts.
+            let processed = self.process_module(&module_path, &module_name)?;
 
             // Extract imports from the processed AST
             let imports_with_context = self.extract_imports_from_facts(
@@ -981,7 +824,7 @@ impl BundleOrchestrator {
         // PHASE 2: Add all modules to graph and create dependency edges
         info!("Phase 2: Adding modules to graph...");
 
-        // First, add all modules to the graph and parse them
+        // First, add all modules to the graph and run semantic analysis.
         let mut parsed_modules: Vec<ParsedModuleData> = Vec::new();
 
         for (discovered_module_id, module_path, imports, _ast, _source) in discovered_modules {
@@ -991,22 +834,15 @@ impl BundleOrchestrator {
                 .unwrap_or_else(|| format!("module_{}", discovered_module_id.as_u32()));
             debug!("Phase 2: Processing module '{module_name}'");
 
-            // Re-process the module WITH graph context this time
-            // This will use cache but also add to graph and do semantic analysis
-            let processed = self.process_module(
-                &module_path,
-                &module_name,
-                Some(params.graph),
-                Some(params.resolver),
-            )?;
-
-            let module_id = processed
-                .module_id
-                .expect("module_id should be set when graph provided");
+            let processed = self.process_module(&module_path, &module_name)?;
+            let module_id = discovered_module_id;
+            params.graph.add_module(module_id, params.resolver);
+            self.conflict_resolver
+                .analyze_module(module_id, &processed.ast, &module_path);
             debug!("Added module to graph: {module_name} with ID {module_id:?}");
 
             // Build dependency graph BEFORE no-ops removal
-            if let Some(module) = params.graph.get_module_by_name_mut(&module_name) {
+            if let Some(module) = params.graph.get_module_mut(module_id) {
                 debug_assert!(
                     module.items.is_empty(),
                     "Module graph should be empty before populating cached facts"
@@ -1055,8 +891,10 @@ impl BundleOrchestrator {
                             .unwrap_or_else(|| base_name.clone());
 
                         // Try to resolve the accessed module name to a ModuleId
-                        if let Some(accessed_module) =
-                            params.graph.get_module_by_name(&resolved_module_name)
+                        if let Some(accessed_module) = params
+                            .resolver
+                            .get_module_id_by_name(&resolved_module_name)
+                            .and_then(|id| params.graph.get_module(id))
                         {
                             // This module accesses resolved_module.__all__
                             all_accesses.push((*accessing_module_id, accessed_module.module_id));
@@ -1754,7 +1592,7 @@ impl BundleOrchestrator {
             }
         }
 
-        let mut static_bundler = Bundler::new(Some(&self.module_registry), params.resolver);
+        let mut static_bundler = Bundler::new(params.resolver);
 
         // Parse all modules and prepare them for bundling
         let mut module_asts = Vec::new();

--- a/crates/cribo/src/resolver.rs
+++ b/crates/cribo/src/resolver.rs
@@ -14,7 +14,10 @@ use log::{debug, info, warn};
 use pep508_rs::PackageName;
 use ruff_python_stdlib::sys;
 
-use crate::{config::Config, types::FxIndexMap};
+use crate::{
+    config::Config,
+    types::{FxIndexMap, FxIndexSet},
+};
 
 /// Unique identifier for a module in the dependency graph
 /// The entry module ALWAYS has ID 0 - this is a fundamental invariant
@@ -467,6 +470,16 @@ impl ModuleResolver {
     pub fn get_module_id_by_name(&self, name: &str) -> Option<ModuleId> {
         let registry = self.registry.lock().expect("Module registry lock poisoned");
         registry.get_id_by_name(name).copied()
+    }
+
+    /// Get registered module IDs whose names start with `prefix`.
+    pub(crate) fn get_module_ids_by_name_prefix(&self, prefix: &str) -> FxIndexSet<ModuleId> {
+        let registry = self.registry.lock().expect("Module registry lock poisoned");
+        registry
+            .by_name
+            .iter()
+            .filter_map(|(name, &id)| name.starts_with(prefix).then_some(id))
+            .collect()
     }
 
     /// Get module ID by path (reverse lookup)

--- a/crates/cribo/src/resolver.rs
+++ b/crates/cribo/src/resolver.rs
@@ -1473,6 +1473,29 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_owns_alias_identity() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let module_path = temp_dir.path().join("utils.py");
+        create_test_file(&module_path, "")?;
+        let resolver = ModuleResolver::new(Config::default());
+
+        let primary_id = resolver.register_module("utils", &module_path);
+        let alias_id = resolver.register_module("src.utils", &module_path);
+
+        assert_eq!(primary_id, alias_id);
+        assert_eq!(resolver.get_module_id_by_name("utils"), Some(primary_id));
+        assert_eq!(
+            resolver.get_module_id_by_name("src.utils"),
+            Some(primary_id)
+        );
+        assert_eq!(
+            resolver.get_module_id_by_path(&module_path),
+            Some(primary_id)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_module_first_resolution() -> Result<()> {
         // Test that foo/__init__.py is preferred over foo.py
         let temp_dir = TempDir::new()?;

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -93,7 +93,7 @@ impl<'a> TreeShaker<'a> {
     /// Resolve a registered name and ensure the module participates in this graph.
     pub(crate) fn get_graph_module_id(&self, module_name: &str) -> Option<ModuleId> {
         let id = self.resolver.get_module_id_by_name(module_name)?;
-        self.graph.modules.get(&id).map(|module| module.module_id)
+        self.graph.modules.contains_key(&id).then_some(id)
     }
 
     /// Analyze which symbols should be kept based on entry point
@@ -932,13 +932,11 @@ impl<'a> TreeShaker<'a> {
         worklist: &mut VecDeque<(ModuleId, String)>,
         context: &str,
     ) {
-        let is_namespace = self
-            .graph
-            .modules
-            .values()
-            .any(|module| module.module_name.starts_with(&format!("{base_var}.")));
+        let prefix = format!("{base_var}.");
+        let mut submodule_ids = self.resolver.get_module_ids_by_name_prefix(&prefix);
+        submodule_ids.retain(|id| self.graph.modules.contains_key(id));
 
-        if !is_namespace {
+        if submodule_ids.is_empty() {
             debug!("Unknown base variable for attribute access in {context}: {base_var}");
             return;
         }
@@ -948,7 +946,7 @@ impl<'a> TreeShaker<'a> {
             debug!("Looking for {attr} in submodules of {base_var}");
 
             // Find which submodule defines this attribute
-            if let Some(module_id) = self.find_attribute_in_submodules(base_var, attr) {
+            if let Some(module_id) = self.find_attribute_in_submodules(&submodule_ids, attr) {
                 debug!(
                     "Found {attr} defined in {}",
                     self.get_module_display_name(module_id)
@@ -961,14 +959,17 @@ impl<'a> TreeShaker<'a> {
     }
 
     /// Find which submodule defines an attribute
-    fn find_attribute_in_submodules(&self, base_var: &str, attr: &str) -> Option<ModuleId> {
-        let prefix = format!("{base_var}.");
-        for (&module_id, module) in &self.graph.modules {
-            if module.module_name.starts_with(&prefix) && module.defines_symbol(attr) {
-                return Some(module_id);
-            }
-        }
-        None
+    fn find_attribute_in_submodules(
+        &self,
+        submodule_ids: &FxIndexSet<ModuleId>,
+        attr: &str,
+    ) -> Option<ModuleId> {
+        submodule_ids.iter().copied().find(|module_id| {
+            self.graph
+                .modules
+                .get(module_id)
+                .is_some_and(|module| module.defines_symbol(attr))
+        })
     }
 
     /// Mark symbols defined in __all__ as used for star imports
@@ -1325,13 +1326,17 @@ mod tests {
     }
 
     #[test]
-    fn test_find_attribute_in_submodules_returns_matching_namespace_submodule() {
+    fn test_find_attribute_in_namespace_resolves_alias_submodule() {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default());
         resolver.register_module("__main__", std::path::Path::new("main.py"));
         let submodule_id = resolver.register_module(
+            "real_pkg.feature",
+            std::path::Path::new("real_pkg/feature.py"),
+        );
+        let alias_id = resolver.register_module(
             "namespace_pkg.feature",
-            std::path::Path::new("namespace_pkg/feature.py"),
+            std::path::Path::new("real_pkg/feature.py"),
         );
 
         graph.add_module(submodule_id, &resolver);
@@ -1343,10 +1348,19 @@ mod tests {
         submodule.add_item(function_item("exported_attr"));
 
         let shaker = TreeShaker::from_graph(&graph, &resolver);
-        let resolved_id = shaker.find_attribute_in_submodules("namespace_pkg", "exported_attr");
-        let missing_id = shaker.find_attribute_in_submodules("namespace_pkg", "nonexistent_attr");
+        let accessed_attrs = std::iter::once("exported_attr".to_owned()).collect();
+        let mut worklist = VecDeque::new();
+        shaker.find_attribute_in_namespace(
+            "namespace_pkg",
+            &accessed_attrs,
+            &mut worklist,
+            "test_module",
+        );
 
-        assert_eq!(resolved_id, Some(submodule_id));
-        assert_eq!(missing_id, None);
+        assert_eq!(alias_id, submodule_id);
+        assert_eq!(
+            worklist.into_iter().collect::<Vec<_>>(),
+            vec![(submodule_id, "exported_attr".to_owned())]
+        );
     }
 }

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -93,11 +93,7 @@ impl<'a> TreeShaker<'a> {
     /// Resolve a registered name and ensure the module participates in this graph.
     pub(crate) fn get_graph_module_id(&self, module_name: &str) -> Option<ModuleId> {
         let id = self.resolver.get_module_id_by_name(module_name)?;
-        self.graph
-            .modules
-            .get(&id)
-            .filter(|module| module.module_name == module_name)
-            .map(|module| module.module_id)
+        self.graph.modules.get(&id).map(|module| module.module_id)
     }
 
     /// Analyze which symbols should be kept based on entry point
@@ -1153,6 +1149,21 @@ mod tests {
             attribute_accesses: FxIndexMap::default(),
             containing_scope: Some(scope_name.to_owned()),
         }
+    }
+
+    #[test]
+    fn test_graph_module_id_accepts_resolver_alias() {
+        let mut graph = DependencyGraph::new();
+        let resolver = ModuleResolver::new(crate::config::Config::default());
+        resolver.register_module("__main__", std::path::Path::new("main.py"));
+        let module_id = resolver.register_module("utils", std::path::Path::new("utils.py"));
+        let alias_id = resolver.register_module("src.utils", std::path::Path::new("utils.py"));
+        graph.add_module(module_id, &resolver);
+
+        let shaker = TreeShaker::from_graph(&graph, &resolver);
+
+        assert_eq!(alias_id, module_id);
+        assert_eq!(shaker.get_graph_module_id("src.utils"), Some(module_id));
     }
 
     #[test]

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -90,6 +90,16 @@ impl<'a> TreeShaker<'a> {
         )
     }
 
+    /// Resolve a registered name and ensure the module participates in this graph.
+    pub(crate) fn get_graph_module_id(&self, module_name: &str) -> Option<ModuleId> {
+        let id = self.resolver.get_module_id_by_name(module_name)?;
+        self.graph
+            .modules
+            .get(&id)
+            .filter(|module| module.module_name == module_name)
+            .map(|module| module.module_id)
+    }
+
     /// Analyze which symbols should be kept based on entry point
     pub(crate) fn analyze(&mut self, entry_module: &str) {
         info!("Starting tree-shaking analysis from entry module: {entry_module}");
@@ -97,7 +107,7 @@ impl<'a> TreeShaker<'a> {
         self.seeded_dynamic_all_modules.borrow_mut().clear();
 
         // Verify that the entry module is registered with the expected ID
-        let entry_id = self.graph.module_names.get(entry_module).copied();
+        let entry_id = self.get_graph_module_id(entry_module);
         if entry_id != Some(ModuleId::ENTRY) {
             warn!("Entry module '{entry_module}' not registered as ModuleId::ENTRY");
             if entry_id.is_none() {
@@ -161,7 +171,7 @@ impl<'a> TreeShaker<'a> {
                         binding.level,
                     );
 
-                    if let Some(&resolved_id) = self.graph.module_names.get(&resolved_module_name) {
+                    if let Some(resolved_id) = self.get_graph_module_id(&resolved_module_name) {
                         return Some((resolved_id, binding.original_name.clone()));
                     }
                 }
@@ -173,7 +183,7 @@ impl<'a> TreeShaker<'a> {
                     &wildcard_import.module,
                     wildcard_import.level,
                 );
-                if let Some(&resolved_id) = self.graph.module_names.get(&resolved_module_name)
+                if let Some(resolved_id) = self.get_graph_module_id(&resolved_module_name)
                     && let Some(target_dep) = self.graph.modules.get(&resolved_id)
                     && target_dep.is_in_all_export(alias)
                 {
@@ -193,7 +203,7 @@ impl<'a> TreeShaker<'a> {
         if let Some(module_dep) = self.graph.modules.get(&current_module_id) {
             if let Some(targets) = module_dep.module_import_aliases_for(alias) {
                 for target in targets {
-                    if let Some(&module_id) = self.graph.module_names.get(target) {
+                    if let Some(module_id) = self.get_graph_module_id(target) {
                         return Some(module_id);
                     }
                 }
@@ -219,7 +229,7 @@ impl<'a> TreeShaker<'a> {
 
                     let potential_full_module =
                         format!("{resolved_module}.{}", binding.original_name);
-                    if let Some(&module_id) = self.graph.module_names.get(&potential_full_module) {
+                    if let Some(module_id) = self.get_graph_module_id(&potential_full_module) {
                         return Some(module_id);
                     }
                 }
@@ -392,8 +402,8 @@ impl<'a> TreeShaker<'a> {
                     let resolved_module_name =
                         self.resolve_import_module_name(module_id, &binding.module, binding.level);
 
-                    if let Some(&resolved_module_id) =
-                        self.graph.module_names.get(&resolved_module_name)
+                    if let Some(resolved_module_id) =
+                        self.get_graph_module_id(&resolved_module_name)
                     {
                         debug!(
                             "Symbol {symbol} is re-exported from \
@@ -413,8 +423,7 @@ impl<'a> TreeShaker<'a> {
                     wildcard_import.level,
                 );
 
-                if let Some(&resolved_module_id) =
-                    self.graph.module_names.get(&resolved_module_name)
+                if let Some(resolved_module_id) = self.get_graph_module_id(&resolved_module_name)
                     && let Some(target_dep) = self.graph.modules.get(&resolved_module_id)
                     && target_dep.is_in_all_export(symbol)
                 {
@@ -507,7 +516,7 @@ impl<'a> TreeShaker<'a> {
         debug!("Marking import {imported_module} as used (inside scope {scope_name})");
 
         // If this imported module has side effects, seed them
-        let Some(&imported_module_id) = self.graph.module_names.get(imported_module) else {
+        let Some(imported_module_id) = self.get_graph_module_id(imported_module) else {
             return;
         };
 
@@ -536,7 +545,7 @@ impl<'a> TreeShaker<'a> {
 
         let resolved_module_name = self.resolve_import_module_name(module_id, from_module, *level);
 
-        if let Some(&from_module_id) = self.graph.module_names.get(&resolved_module_name)
+        if let Some(from_module_id) = self.get_graph_module_id(&resolved_module_name)
             && self.module_has_side_effects(from_module_id)
         {
             self.seed_side_effects_for_module(from_module_id, worklist);
@@ -572,7 +581,7 @@ impl<'a> TreeShaker<'a> {
         resolved_module_name: &str,
         worklist: &mut VecDeque<(ModuleId, String)>,
     ) {
-        let Some(&resolved_module_id) = self.graph.module_names.get(resolved_module_name) else {
+        let Some(resolved_module_id) = self.get_graph_module_id(resolved_module_name) else {
             return;
         };
 
@@ -610,7 +619,7 @@ impl<'a> TreeShaker<'a> {
         potential_module: &str,
         worklist: &mut VecDeque<(ModuleId, String)>,
     ) {
-        let Some(&submodule_id) = self.graph.module_names.get(potential_module) else {
+        let Some(submodule_id) = self.get_graph_module_id(potential_module) else {
             return;
         };
 
@@ -753,27 +762,23 @@ impl<'a> TreeShaker<'a> {
 
     /// Get symbols that survive tree-shaking for a module
     pub(crate) fn get_used_symbols_for_module(&self, module_name: &str) -> FxIndexSet<String> {
-        // Get the ModuleId for this module name
-        if let Some(&module_id) = self.graph.module_names.get(module_name) {
-            self.used_symbols
-                .iter()
-                .filter(|(id, _)| *id == module_id)
-                .map(|(_, symbol)| symbol.clone())
-                .collect()
-        } else {
-            FxIndexSet::default()
-        }
+        self.get_graph_module_id(module_name)
+            .map_or_else(FxIndexSet::default, |module_id| {
+                self.used_symbols
+                    .iter()
+                    .filter(|(id, _)| *id == module_id)
+                    .map(|(_, symbol)| symbol.clone())
+                    .collect()
+            })
     }
 
     /// Check if a symbol is used after tree-shaking
     pub(crate) fn is_symbol_used(&self, module_name: &str, symbol_name: &str) -> bool {
-        // Get the ModuleId for this module name
-        if let Some(&module_id) = self.graph.module_names.get(module_name) {
-            self.used_symbols
-                .contains(&(module_id, symbol_name.to_owned()))
-        } else {
-            false
-        }
+        self.get_graph_module_id(module_name)
+            .is_some_and(|module_id| {
+                self.used_symbols
+                    .contains(&(module_id, symbol_name.to_owned()))
+            })
     }
 
     // Removed get_unused_symbols_for_module: dead code
@@ -909,7 +914,7 @@ impl<'a> TreeShaker<'a> {
                     worklist.push_back((source_module_id, attr.clone()));
                 }
             // 4) Direct module reference like `import greetings`
-            } else if let Some(&base_module_id) = self.graph.module_names.get(base_var) {
+            } else if let Some(base_module_id) = self.get_graph_module_id(base_var) {
                 for attr in accessed_attrs {
                     debug!(
                         "Found direct module attribute access in {module_name}: {base_var}.{attr}"
@@ -933,9 +938,9 @@ impl<'a> TreeShaker<'a> {
     ) {
         let is_namespace = self
             .graph
-            .module_names
-            .keys()
-            .any(|name| name.starts_with(&format!("{base_var}.")));
+            .modules
+            .values()
+            .any(|module| module.module_name.starts_with(&format!("{base_var}.")));
 
         if !is_namespace {
             debug!("Unknown base variable for attribute access in {context}: {base_var}");
@@ -962,13 +967,9 @@ impl<'a> TreeShaker<'a> {
     /// Find which submodule defines an attribute
     fn find_attribute_in_submodules(&self, base_var: &str, attr: &str) -> Option<ModuleId> {
         let prefix = format!("{base_var}.");
-        for (name, &module_id) in &self.graph.module_names {
-            if name.starts_with(&prefix) {
-                if let Some(module_dep) = self.graph.modules.get(&module_id)
-                    && module_dep.defines_symbol(attr)
-                {
-                    return Some(module_id);
-                }
+        for (&module_id, module) in &self.graph.modules {
+            if module.module_name.starts_with(&prefix) && module.defines_symbol(attr) {
+                return Some(module_id);
             }
         }
         None
@@ -1158,13 +1159,11 @@ mod tests {
     fn test_basic_tree_shaking() {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default());
+        let entry_id = resolver.register_module("__main__", std::path::Path::new("main.py"));
+        let module_id = resolver.register_module("test_module", std::path::Path::new("test.py"));
 
         // Create a simple module with used and unused functions
-        let module_id = graph.add_module(
-            ModuleId::new(1),
-            "test_module".to_owned(),
-            &std::path::PathBuf::from("test.py"),
-        );
+        graph.add_module(module_id, &resolver);
         let module = graph
             .modules
             .get_mut(&module_id)
@@ -1209,11 +1208,7 @@ mod tests {
         });
 
         // Add entry module that uses only used_func
-        let entry_id = graph.add_module(
-            ModuleId::new(0),
-            "__main__".to_owned(),
-            &std::path::PathBuf::from("main.py"),
-        );
+        graph.add_module(entry_id, &resolver);
         let entry = graph
             .modules
             .get_mut(&entry_id)
@@ -1251,12 +1246,11 @@ mod tests {
     fn test_mark_all_symbols_from_module_all_as_used_falls_back_to_local_symbol() {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default());
+        resolver.register_module("__main__", std::path::Path::new("main.py"));
+        let module_id =
+            resolver.register_module("all_module", std::path::Path::new("all_module.py"));
 
-        let module_id = graph.add_module(
-            ModuleId::new(1),
-            "all_module".to_owned(),
-            &std::path::PathBuf::from("all_module.py"),
-        );
+        graph.add_module(module_id, &resolver);
         let module = graph
             .modules
             .get_mut(&module_id)
@@ -1296,12 +1290,11 @@ mod tests {
     fn test_mark_scoped_imports_marks_local_import_bindings_used() {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default());
+        resolver.register_module("__main__", std::path::Path::new("main.py"));
+        let module_id =
+            resolver.register_module("scoped_imports", std::path::Path::new("scoped_imports.py"));
 
-        let module_id = graph.add_module(
-            ModuleId::new(1),
-            "scoped_imports".to_owned(),
-            &std::path::PathBuf::from("scoped_imports.py"),
-        );
+        graph.add_module(module_id, &resolver);
         let module = graph
             .modules
             .get_mut(&module_id)
@@ -1324,12 +1317,13 @@ mod tests {
     fn test_find_attribute_in_submodules_returns_matching_namespace_submodule() {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default());
-
-        let submodule_id = graph.add_module(
-            ModuleId::new(1),
-            "namespace_pkg.feature".to_owned(),
-            &std::path::PathBuf::from("namespace_pkg/feature.py"),
+        resolver.register_module("__main__", std::path::Path::new("main.py"));
+        let submodule_id = resolver.register_module(
+            "namespace_pkg.feature",
+            std::path::Path::new("namespace_pkg/feature.py"),
         );
+
+        graph.add_module(submodule_id, &resolver);
         let submodule = graph
             .modules
             .get_mut(&submodule_id)

--- a/crates/cribo/tests/snapshots/bundled_code@xfail_file_deduplication_symlinks.snap
+++ b/crates/cribo/tests/snapshots/bundled_code@xfail_file_deduplication_symlinks.snap
@@ -42,9 +42,6 @@ lib_helpers.counter = counter
 lib_helpers.get_location = get_location
 lib_helpers.increment_counter = increment_counter
 shared = _cribo.types.SimpleNamespace(__name__='shared')
-shared.counter = counter
-shared.get_location = get_location
-shared.increment_counter = increment_counter
 helpers = lib_helpers
 common = lib_helpers
 print(f"helpers location: {helpers.get_location()}")

--- a/crates/cribo/tests/snapshots/execution_results@xfail_file_deduplication_symlinks.snap
+++ b/crates/cribo/tests/snapshots/execution_results@xfail_file_deduplication_symlinks.snap
@@ -7,5 +7,5 @@ ExecutionResults {
         1,
     ),
     stdout: "helpers location: lib/helpers.py\ncommon location: lib/helpers.py\nhelpers counter: 1\ncommon counter: 2",
-    stderr: "Traceback (most recent call last):\n  File \"<stdin>\", line 50, in <module>",
+    stderr: "Traceback (most recent call last):\n  File \"<stdin>\", line 47, in <module>",
 }


### PR DESCRIPTION
## Summary

- make `ModuleResolver` the single owner of module IDs, names, canonical paths, and aliases
- reduce `DependencyGraph` to graph membership and topology keyed by resolver-assigned IDs
- keep `ProcessedModule` focused on cached parse products and perform graph insertion and semantic analysis explicitly in graph-build phase 2
- remove the duplicate orchestrator/code-generation registry and derive wrapper state from existing bundled/inlined classification sets
- add regression coverage for resolver-owned alias identity and idempotent graph insertion

## Why

Issue #514 identified competing identity stores with different duplicate and conflict behavior. Consolidating identity in the resolver prevents IDs, names, and paths from drifting between resolution, graph construction, tree shaking, and code generation.

This is a refactor with no intended bundled-output changes.

Closes #514

## Validation

- `cargo clippy --workspace --all-targets --all-features`
- `cargo nextest run --workspace -E 'not test(test_ecosystem_all)'` (173 passed, 1 skipped)
- `git diff --check`

The aggregate ecosystem test was excluded because the existing worktree has modified `httpx`, `idna`, and `pyyaml` submodules plus uninitialized `requests` and `rich` submodules. Those pre-existing states were left untouched.