### PR TITLE
Reject conflicting module-name resolutions

### DIFF
--- a/crates/cribo/benches/bundling.rs
+++ b/crates/cribo/benches/bundling.rs
@@ -136,9 +136,15 @@ fn benchmark_dependency_graph(c: &mut Criterion) {
 
     let resolver =
         ModuleResolver::new(Config::default()).expect("benchmark configuration should be valid");
-    let main_id = resolver.register_module("main", Path::new("main.py"));
-    let utils_id = resolver.register_module("utils.helpers", Path::new("utils/helpers.py"));
-    let models_id = resolver.register_module("models.user", Path::new("models/user.py"));
+    let main_id = resolver
+        .register_module("main", Path::new("main.py"))
+        .expect("benchmark module registration should succeed");
+    let utils_id = resolver
+        .register_module("utils.helpers", Path::new("utils/helpers.py"))
+        .expect("benchmark module registration should succeed");
+    let models_id = resolver
+        .register_module("models.user", Path::new("models/user.py"))
+        .expect("benchmark module registration should succeed");
 
     c.bench_function("build_dependency_graph", |b| {
         b.iter(|| {

--- a/crates/cribo/src/analyzers/import_analyzer.rs
+++ b/crates/cribo/src/analyzers/import_analyzer.rs
@@ -931,7 +931,9 @@ mod tests {
         let resolver = ModuleResolver::new(config).expect("test configuration should be valid");
         let mut modules = FxIndexMap::default();
         for (name, ast, path, hash) in entries {
-            let id = resolver.register_module(name, &path);
+            let id = resolver
+                .register_module(name, &path)
+                .expect("test module registration should succeed");
             modules.insert(id, (Arc::new(ast), path, hash.to_owned()));
         }
         (resolver, modules)

--- a/crates/cribo/src/analyzers/module_classifier.rs
+++ b/crates/cribo/src/analyzers/module_classifier.rs
@@ -21,7 +21,6 @@ pub(crate) struct ClassificationResult {
 /// Analyzes and classifies modules for bundling
 pub(crate) struct ModuleClassifier<'a> {
     resolver: &'a ModuleResolver,
-    entry_is_package_init_or_main: bool,
     modules_with_explicit_all: FxIndexSet<ModuleId>,
     namespace_imported_modules: FxIndexMap<ModuleId, FxIndexSet<ModuleId>>,
     circular_modules: FxIndexSet<ModuleId>,
@@ -31,29 +30,22 @@ impl<'a> ModuleClassifier<'a> {
     /// Create a new module classifier
     pub(crate) fn new(
         resolver: &'a ModuleResolver,
-        entry_is_package_init_or_main: bool,
         namespace_imported_modules: FxIndexMap<ModuleId, FxIndexSet<ModuleId>>,
         circular_modules: FxIndexSet<ModuleId>,
     ) -> Self {
         Self {
             resolver,
-            entry_is_package_init_or_main,
             modules_with_explicit_all: FxIndexSet::default(),
             namespace_imported_modules,
             circular_modules,
         }
     }
 
-    /// Get the entry package name when entry is a package __init__.py or __main__.py
-    /// Returns None if entry is not a package __init__.py or __main__.py
+    /// Get the entry package name when entry is a package `__init__.py`.
     fn entry_package_name(&self) -> Option<String> {
         let entry_module_name = self.resolver.get_module_name(ModuleId::ENTRY)?;
-        // Strip ".<init>" or ".<main>" suffix if present; bare "__init__"/"__main__" have no pkg.
         entry_module_name
             .strip_suffix(&format!(".{}", crate::python::constants::INIT_STEM))
-            .or_else(|| {
-                entry_module_name.strip_suffix(&format!(".{}", crate::python::constants::MAIN_STEM))
-            })
             .map(str::to_owned)
     }
 
@@ -87,7 +79,7 @@ impl<'a> ModuleClassifier<'a> {
 
             // Also skip if this is the entry package itself when entry is a package __init__.py
             // e.g., skip "yaml" when entry is "yaml.__init__"
-            if self.entry_is_package_init_or_main {
+            if self.resolver.is_package_init(ModuleId::ENTRY) {
                 if let Some(entry_pkg) = self.entry_package_name() {
                     if module_name == entry_pkg {
                         debug!(

--- a/crates/cribo/src/code_generator/bundler/symbols.rs
+++ b/crates/cribo/src/code_generator/bundler/symbols.rs
@@ -1038,7 +1038,9 @@ mod tests {
     fn test_type_checking_import_collector_treats_not_type_checking_continuations_as_type_only() {
         let resolver =
             ModuleResolver::new(Config::default()).expect("default configuration should be valid");
-        let imported_id = resolver.register_module("types_mod", Path::new("types_mod.py"));
+        let imported_id = resolver
+            .register_module("types_mod", Path::new("types_mod.py"))
+            .expect("test module registration should succeed");
 
         let statements = ruff_python_parser::parse_module(
             r"

--- a/crates/cribo/src/code_generator/phases/classification.rs
+++ b/crates/cribo/src/code_generator/phases/classification.rs
@@ -47,7 +47,6 @@ impl ClassificationPhase {
         // Classify modules into inlinable and wrapper modules
         let classifier = ModuleClassifier::new(
             bundler.resolver,
-            bundler.entry_is_package_init_or_main,
             bundler.namespace_imported_modules.clone(),
             bundler.circular_modules.clone(),
         );

--- a/crates/cribo/src/code_generator/phases/entry_module.rs
+++ b/crates/cribo/src/code_generator/phases/entry_module.rs
@@ -95,7 +95,7 @@ impl EntryModulePhase {
         Self::transform_entry_imports(bundler, &mut ast, symbol_renames, params.python_version);
 
         // Process statements with deduplication
-        let mut entry_statements = Vec::new();
+        let mut entry_statements = Self::initialize_package_for_main_entry(bundler, &module_name);
         Self::process_entry_statements(
             bundler,
             &ast,
@@ -119,6 +119,27 @@ impl EntryModulePhase {
             entry_symbols: entry_module_symbols,
             entry_renames: entry_module_renames,
         })
+    }
+
+    /// Initialize the containing package before executing a package's `__main__.py`.
+    fn initialize_package_for_main_entry(bundler: &Bundler<'_>, module_name: &str) -> Vec<Stmt> {
+        if bundler.resolver.get_module_kind(ModuleId::ENTRY)
+            != Some(crate::python::module_path::ModuleKind::Main)
+        {
+            return Vec::new();
+        }
+
+        let Some(package_name) =
+            module_name.strip_suffix(&format!(".{}", crate::python::constants::MAIN_STEM))
+        else {
+            return Vec::new();
+        };
+        let Some(package_id) = bundler.get_module_id(package_name) else {
+            return Vec::new();
+        };
+
+        log::debug!("Initializing entry package '{package_name}' before '{module_name}'");
+        bundler.create_module_initialization_for_import(package_id)
     }
 
     /// Reorder entry module statements for circular dependencies

--- a/crates/cribo/src/dependency_graph.rs
+++ b/crates/cribo/src/dependency_graph.rs
@@ -745,7 +745,11 @@ mod tests {
             ModuleResolver::new(Config::default()).expect("default configuration should be valid");
         let ids = names
             .iter()
-            .map(|name| resolver.register_module(name, std::path::Path::new(name)))
+            .map(|name| {
+                resolver
+                    .register_module(name, std::path::Path::new(name))
+                    .expect("test module registration should succeed")
+            })
             .collect();
         (resolver, ids)
     }

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -327,7 +327,7 @@ impl BundleOrchestrator {
 
         // CRITICAL: Register the entry module FIRST to guarantee it gets ID 0
         // This is a fundamental invariant of our architecture
-        let entry_id = resolver.register_module(&entry_module_name, entry_path);
+        let entry_id = resolver.register_module(&entry_module_name, entry_path)?;
         assert_eq!(
             entry_id,
             ModuleId::ENTRY,
@@ -1178,7 +1178,7 @@ impl BundleOrchestrator {
         import: &str,
         import_path: PathBuf,
         discovery_params: &mut DiscoveryParams<'_>,
-    ) {
+    ) -> Result<()> {
         // For first-party modules, derive the actual module name from the path
         // This is critical for relative imports where the import string might be incomplete
         // For example, "jupyter" might actually be "rich.jupyter"
@@ -1279,7 +1279,7 @@ impl BundleOrchestrator {
         // it returns the existing ID
         let module_id = discovery_params
             .resolver
-            .register_module(&actual_module_name, &import_path);
+            .register_module(&actual_module_name, &import_path)?;
 
         if !discovery_params.processed_modules.contains(&module_id)
             && !discovery_params.queued_modules.contains(&module_id)
@@ -1302,18 +1302,24 @@ impl BundleOrchestrator {
                 import
             );
         }
+        Ok(())
     }
 
     /// Add parent packages to discovery queue to ensure __init__.py files are included
     /// For example, if importing "greetings.irrelevant", also add "greetings"
-    fn add_parent_packages_to_discovery(&self, import: &str, params: &mut DiscoveryParams<'_>) {
+    fn add_parent_packages_to_discovery(
+        &self,
+        import: &str,
+        params: &mut DiscoveryParams<'_>,
+    ) -> Result<()> {
         let parts: Vec<&str> = import.split('.').collect();
 
         // For each parent package level, try to add it to discovery
         for i in 1..parts.len() {
             let parent_module = parts[..i].join(".");
-            self.try_add_parent_package_to_discovery(&parent_module, import, params);
+            self.try_add_parent_package_to_discovery(&parent_module, import, params)?;
         }
+        Ok(())
     }
 
     /// Try to add a single parent package to discovery if it's first-party
@@ -1322,7 +1328,7 @@ impl BundleOrchestrator {
         parent_module: &str,
         import: &str,
         params: &mut DiscoveryParams<'_>,
-    ) {
+    ) -> Result<()> {
         if params
             .resolver
             .classify_import(parent_module)
@@ -1333,11 +1339,12 @@ impl BundleOrchestrator {
                     "Adding parent package '{parent_module}' to discovery queue for import \
                      '{import}'"
                 );
-                self.add_to_discovery_queue_if_new(parent_module, parent_path, params);
+                self.add_to_discovery_queue_if_new(parent_module, parent_path, params)?;
             }
         } else {
             // Parent is not first-party, processing stops here
         }
+        Ok(())
     }
 
     /// Process an import during discovery phase with error handling context
@@ -1363,7 +1370,7 @@ impl BundleOrchestrator {
                     import_path.display()
                 );
                 // Use the resolved name instead of the original import
-                self.add_to_discovery_queue_if_new(&resolved_name, import_path, params);
+                self.add_to_discovery_queue_if_new(&resolved_name, import_path, params)?;
             } else {
                 // Try normal resolution in case it's a valid Python identifier
                 let classification = params.resolver.classify_import(import);
@@ -1373,7 +1380,7 @@ impl BundleOrchestrator {
                             "Resolved ImportlibStatic '{import}' to path: {}",
                             import_path.display()
                         );
-                        self.add_to_discovery_queue_if_new(import, import_path, params);
+                        self.add_to_discovery_queue_if_new(import, import_path, params)?;
                     } else if !is_in_error_handler {
                         return Err(anyhow!(
                             "Failed to resolve ImportlibStatic module '{import}'. \nThis import \
@@ -1395,12 +1402,12 @@ impl BundleOrchestrator {
                 );
                 if let Ok(Some(import_path)) = params.resolver.resolve_module_path(import) {
                     debug!("Resolved '{import}' to path: {}", import_path.display());
-                    self.add_to_discovery_queue_if_new(import, import_path, params);
+                    self.add_to_discovery_queue_if_new(import, import_path, params)?;
 
                     // Also add parent packages for submodules to ensure __init__.py files are
                     // included For example, if importing
                     // "greetings.irrelevant", also add "greetings"
-                    self.add_parent_packages_to_discovery(import, params);
+                    self.add_parent_packages_to_discovery(import, params)?;
                 } else {
                     // If the import is not in an error handler, this is a fatal error
                     if is_in_error_handler {

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -690,7 +690,7 @@ impl BundleOrchestrator {
             return Ok(crate::python::constants::INIT_STEM.to_owned());
         }
 
-        // Special case: If the entry is __main__.py in a package, use the package name
+        // Special case: If the entry is __main__.py in a package, preserve the module suffix
         let file_name = entry_path.file_name().and_then(|f| f.to_str());
         log::debug!("Entry file name: {file_name:?}");
         if file_name.is_some_and(crate::python::module_path::is_main_file_name) {
@@ -698,12 +698,14 @@ impl BundleOrchestrator {
             if let Some(parent) = entry_path.parent()
                 && let Some(package_name) = self.find_module_in_src_dirs(parent)
             {
+                let module_name = format!("{package_name}.{}", crate::python::constants::MAIN_STEM);
                 log::debug!(
-                    "Entry is {} in package '{}', using package name as module name",
+                    "Entry is {} in package '{}', using '{}' as module name",
                     crate::python::constants::MAIN_FILE,
-                    package_name
+                    package_name,
+                    module_name
                 );
-                return Ok(package_name);
+                return Ok(module_name);
             }
             // Fall through to normal logic if we can't determine the package name
         }
@@ -1341,8 +1343,6 @@ impl BundleOrchestrator {
                 );
                 self.add_to_discovery_queue_if_new(parent_module, parent_path, params)?;
             }
-        } else {
-            // Parent is not first-party, processing stops here
         }
         Ok(())
     }

--- a/crates/cribo/src/orchestrator.rs
+++ b/crates/cribo/src/orchestrator.rs
@@ -750,6 +750,11 @@ impl BundleOrchestrator {
         let mut modules_to_process = ModuleQueue::new();
         modules_to_process.push((ModuleId::ENTRY, entry_path));
         queued_modules.insert(ModuleId::ENTRY);
+        Self::queue_main_entry_package_initializer(
+            params.resolver,
+            &mut modules_to_process,
+            &mut queued_modules,
+        )?;
 
         // Store module data for phase 2, including the parse products.
         type DiscoveryData = (ModuleId, PathBuf, Vec<String>, ProcessedModule);
@@ -929,6 +934,44 @@ impl BundleOrchestrator {
             params.graph.modules.len()
         );
         Ok(parsed_modules)
+    }
+
+    /// Queue the containing package so its initializer runs before a package `__main__.py`.
+    fn queue_main_entry_package_initializer(
+        resolver: &ModuleResolver,
+        modules_to_process: &mut ModuleQueue,
+        queued_modules: &mut IndexSet<ModuleId>,
+    ) -> Result<()> {
+        if resolver.get_module_kind(ModuleId::ENTRY)
+            != Some(crate::python::module_path::ModuleKind::Main)
+        {
+            return Ok(());
+        }
+
+        let Some(entry_module_name) = resolver.get_module_name(ModuleId::ENTRY) else {
+            return Ok(());
+        };
+        let Some(package_name) =
+            entry_module_name.strip_suffix(&format!(".{}", crate::python::constants::MAIN_STEM))
+        else {
+            return Ok(());
+        };
+        if !resolver.classify_import(package_name).should_bundle() {
+            return Ok(());
+        }
+        let Some(package_path) = resolver.resolve_module_path(package_name)? else {
+            return Ok(());
+        };
+
+        let package_id = resolver.register_module(package_name, &package_path)?;
+        if queued_modules.insert(package_id) {
+            debug!(
+                "Adding entry package initializer '{}' to discovery queue",
+                package_path.display()
+            );
+            modules_to_process.push((package_id, package_path));
+        }
+        Ok(())
     }
 
     /// Resolve imports from precomputed module facts with full context information.

--- a/crates/cribo/src/resolver.rs
+++ b/crates/cribo/src/resolver.rs
@@ -108,33 +108,29 @@ impl ModuleRegistry {
         }
     }
 
-    fn register(&mut self, name: String, path: &Path) -> ModuleId {
+    fn register(&mut self, name: String, path: &Path) -> Result<ModuleId> {
         // `path` is expected to be canonicalized by the caller
         let canonical_path = path.to_owned();
 
-        // Check for duplicates
-        if let Some(&id) = self.by_name.get(&name)
-            && self.by_id[&id].canonical_path == canonical_path
-        {
-            return id;
+        if let Some(&id) = self.by_name.get(&name) {
+            let existing = self
+                .by_id
+                .get(&id)
+                .expect("Module name must reference registered metadata");
+            if existing.canonical_path == canonical_path {
+                return Ok(id);
+            }
+            return Err(anyhow!(
+                "Import name '{}' resolves to conflicting files: '{}' and '{}'",
+                name,
+                existing.canonical_path.display(),
+                canonical_path.display()
+            ));
         }
 
         if let Some(&id) = self.by_path.get(&canonical_path) {
-            // Only update by_name if the name isn't already taken
-            // This prevents overwriting the entry module's name when __init__.py is found later
-            match self.by_name.get(&name) {
-                None => {
-                    self.by_name.insert(name, id);
-                }
-                Some(existing) if *existing != id => {
-                    log::warn!(
-                        "register(): name '{name}' already mapped to {existing:?}, but path maps \
-                         to {id:?}; keeping existing name mapping"
-                    );
-                }
-                _ => {}
-            }
-            return id;
+            self.by_name.insert(name, id);
+            return Ok(id);
         }
 
         // Allocate ID - entry gets 0, others get sequential IDs
@@ -189,23 +185,10 @@ impl ModuleRegistry {
         };
 
         self.by_id.insert(id, metadata);
-        // Only insert the name if it's not already taken
-        // This prevents __init__.py from overwriting __main__.py's name when both exist
-        match self.by_name.get(&name) {
-            None => {
-                self.by_name.insert(name, id);
-            }
-            Some(existing) if *existing != id => {
-                log::warn!(
-                    "register(): name '{name}' already mapped to {existing:?}, but newly \
-                     registered id is {id:?}; keeping existing name mapping"
-                );
-            }
-            _ => {}
-        }
+        self.by_name.insert(name, id);
         self.by_path.insert(canonical_path, id);
 
-        id
+        Ok(id)
     }
 
     fn get_metadata(&self, id: ModuleId) -> Option<&ModuleMetadata> {
@@ -1607,13 +1590,16 @@ impl ModuleResolver {
         Some(parts)
     }
 
-    /// Register a module - entry gets 0, others get sequential IDs
-    pub fn register_module(&self, name: &str, path: &Path) -> ModuleId {
+    /// Register a module, rejecting names that resolve to a different canonical file.
+    ///
+    /// The entry module gets ID 0 and later modules receive sequential IDs. Registering another
+    /// name for an existing canonical path creates an alias for the existing module.
+    pub fn register_module(&self, name: &str, path: &Path) -> Result<ModuleId> {
         let canonical = self.canonicalize_path(path.to_path_buf());
         let id = {
             let mut registry = self.registry.lock().expect("Module registry lock poisoned");
             registry.register(name.to_owned(), &canonical)
-        };
+        }?;
         let is_package = {
             let registry = self.registry.lock().expect("Module registry lock poisoned");
             registry.get_metadata(id).is_some_and(|m| m.is_package)
@@ -1630,7 +1616,7 @@ impl ModuleResolver {
             );
         }
 
-        id
+        Ok(id)
     }
 }
 
@@ -1684,8 +1670,8 @@ mod tests {
         create_test_file(&module_path, "")?;
         let resolver = ModuleResolver::new(Config::default())?;
 
-        let primary_id = resolver.register_module("utils", &module_path);
-        let alias_id = resolver.register_module("src.utils", &module_path);
+        let primary_id = resolver.register_module("utils", &module_path)?;
+        let alias_id = resolver.register_module("src.utils", &module_path)?;
 
         assert_eq!(primary_id, alias_id);
         assert_eq!(resolver.get_module_id_by_name("utils"), Some(primary_id));
@@ -1696,6 +1682,34 @@ mod tests {
         assert_eq!(
             resolver.get_module_id_by_path(&module_path),
             Some(primary_id)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_registry_rejects_conflicting_module_name_paths() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let first_path = temp_dir.path().join("first/shared.py");
+        let second_path = temp_dir.path().join("second/shared.py");
+        create_test_file(&first_path, "SOURCE = 'first'")?;
+        create_test_file(&second_path, "SOURCE = 'second'")?;
+        let resolver = ModuleResolver::new(Config::default())?;
+
+        let first_id = resolver.register_module("shared", &first_path)?;
+        let error = resolver
+            .register_module("shared", &second_path)
+            .expect_err("one import name must not resolve to multiple files");
+
+        assert_eq!(resolver.get_module_id_by_name("shared"), Some(first_id));
+        assert_eq!(resolver.get_module_id_by_path(&first_path), Some(first_id));
+        assert_eq!(resolver.get_module_id_by_path(&second_path), None);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Import name 'shared' resolves to conflicting files: '{}' and '{}'",
+                first_path.canonicalize()?.display(),
+                second_path.canonicalize()?.display()
+            )
         );
         Ok(())
     }

--- a/crates/cribo/src/tree_shaking.rs
+++ b/crates/cribo/src/tree_shaking.rs
@@ -1206,9 +1206,15 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id = resolver.register_module("utils", std::path::Path::new("utils.py"));
-        let alias_id = resolver.register_module("src.utils", std::path::Path::new("utils.py"));
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("utils", std::path::Path::new("utils.py"))
+            .expect("test module registration should succeed");
+        let alias_id = resolver
+            .register_module("src.utils", std::path::Path::new("utils.py"))
+            .expect("test alias registration should succeed");
         graph.add_module(module_id, &resolver);
 
         let shaker = TreeShaker::from_graph(&graph, &resolver);
@@ -1222,8 +1228,12 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        let entry_id = resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id = resolver.register_module("test_module", std::path::Path::new("test.py"));
+        let entry_id = resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("test_module", std::path::Path::new("test.py"))
+            .expect("test module registration should succeed");
 
         // Create a simple module with used and unused functions
         graph.add_module(module_id, &resolver);
@@ -1312,9 +1322,12 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id =
-            resolver.register_module("all_module", std::path::Path::new("all_module.py"));
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("all_module", std::path::Path::new("all_module.py"))
+            .expect("test module registration should succeed");
 
         graph.add_module(module_id, &resolver);
         let module = graph
@@ -1360,10 +1373,15 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id =
-            resolver.register_module("scoped_imports", std::path::Path::new("scoped_imports.py"));
-        let operator_id = resolver.register_module("operator", std::path::Path::new("operator.py"));
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("scoped_imports", std::path::Path::new("scoped_imports.py"))
+            .expect("test module registration should succeed");
+        let operator_id = resolver
+            .register_module("operator", std::path::Path::new("operator.py"))
+            .expect("test module registration should succeed");
 
         graph.add_module(module_id, &resolver);
         let module = graph
@@ -1403,9 +1421,12 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id =
-            resolver.register_module("scoped_side_effect", std::path::Path::new("module.py"));
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("scoped_side_effect", std::path::Path::new("module.py"))
+            .expect("test module registration should succeed");
 
         graph.add_module(module_id, &resolver);
         let module = graph
@@ -1455,9 +1476,12 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let module_id =
-            resolver.register_module("class_side_effect", std::path::Path::new("module.py"));
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let module_id = resolver
+            .register_module("class_side_effect", std::path::Path::new("module.py"))
+            .expect("test module registration should succeed");
 
         graph.add_module(module_id, &resolver);
         let module = graph
@@ -1490,15 +1514,21 @@ mod tests {
         let mut graph = DependencyGraph::new();
         let resolver = ModuleResolver::new(crate::config::Config::default())
             .expect("default configuration should be valid");
-        resolver.register_module("__main__", std::path::Path::new("main.py"));
-        let submodule_id = resolver.register_module(
-            "real_pkg.feature",
-            std::path::Path::new("real_pkg/feature.py"),
-        );
-        let alias_id = resolver.register_module(
-            "namespace_pkg.feature",
-            std::path::Path::new("real_pkg/feature.py"),
-        );
+        resolver
+            .register_module("__main__", std::path::Path::new("main.py"))
+            .expect("entry module registration should succeed");
+        let submodule_id = resolver
+            .register_module(
+                "real_pkg.feature",
+                std::path::Path::new("real_pkg/feature.py"),
+            )
+            .expect("test module registration should succeed");
+        let alias_id = resolver
+            .register_module(
+                "namespace_pkg.feature",
+                std::path::Path::new("real_pkg/feature.py"),
+            )
+            .expect("test alias registration should succeed");
 
         graph.add_module(submodule_id, &resolver);
         let submodule = graph

--- a/crates/cribo/tests/test_directory_entry_simple.rs
+++ b/crates/cribo/tests/test_directory_entry_simple.rs
@@ -154,6 +154,54 @@ print("Running from __main__.py")
 }
 
 #[test]
+fn test_explicit_package_main_entry_with_sibling_import() {
+    let temp_dir = TempDir::new().unwrap();
+    let package_dir = temp_dir.path().join("testpkg");
+    fs::create_dir_all(&package_dir).unwrap();
+
+    fs::write(
+        package_dir.join("__init__.py"),
+        r#"print("Initializing package")"#,
+    )
+    .unwrap();
+    fs::write(package_dir.join("sibling.py"), r#"VALUE = "from sibling""#).unwrap();
+    fs::write(
+        package_dir.join("__main__.py"),
+        r#"from .sibling import VALUE
+
+print(f"Running entry {VALUE}")
+"#,
+    )
+    .unwrap();
+
+    let output_path = temp_dir.path().join("bundled.py");
+    let entry_path = package_dir.join("__main__.py");
+
+    let (_, stderr, exit_code) = run_cribo(&[
+        "--entry",
+        entry_path.to_str().unwrap(),
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(exit_code, 0, "Bundling failed: {stderr}");
+
+    let python_output = Command::new("python3")
+        .arg(&output_path)
+        .output()
+        .expect("Failed to execute Python");
+    let python_stdout = String::from_utf8_lossy(&python_output.stdout);
+    let bundled_content = fs::read_to_string(&output_path).unwrap();
+
+    assert!(python_output.status.success());
+    assert_eq!(
+        python_stdout.lines().collect::<Vec<_>>(),
+        ["Initializing package", "Running entry from sibling"],
+        "Generated bundle:\n{bundled_content}"
+    );
+}
+
+#[test]
 fn test_directory_entry_empty_dir_error() {
     let temp_dir = TempDir::new().unwrap();
     let empty_dir = temp_dir.path().join("empty");

--- a/crates/cribo/tests/test_directory_entry_simple.rs
+++ b/crates/cribo/tests/test_directory_entry_simple.rs
@@ -154,7 +154,8 @@ print("Running from __main__.py")
 }
 
 #[test]
-fn test_explicit_package_main_entry_with_sibling_import() {
+fn test_explicit_package_main_entry_initializes_package() {
+    // The snapshot fixture harness always enters main.py, so it cannot exercise this CLI path.
     let temp_dir = TempDir::new().unwrap();
     let package_dir = temp_dir.path().join("testpkg");
     fs::create_dir_all(&package_dir).unwrap();
@@ -197,6 +198,39 @@ print(f"Running entry {VALUE}")
     assert_eq!(
         python_stdout.lines().collect::<Vec<_>>(),
         ["Initializing package", "Running entry from sibling"],
+        "Generated bundle:\n{bundled_content}"
+    );
+
+    fs::write(
+        &entry_path,
+        r#"print("Running entry without package imports")"#,
+    )
+    .unwrap();
+    let standalone_output_path = temp_dir.path().join("standalone-bundled.py");
+
+    let (_, stderr, exit_code) = run_cribo(&[
+        "--entry",
+        entry_path.to_str().unwrap(),
+        "--output",
+        standalone_output_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(exit_code, 0, "Bundling failed: {stderr}");
+
+    let python_output = Command::new("python3")
+        .arg(&standalone_output_path)
+        .output()
+        .expect("Failed to execute Python");
+    let python_stdout = String::from_utf8_lossy(&python_output.stdout);
+    let bundled_content = fs::read_to_string(&standalone_output_path).unwrap();
+
+    assert!(python_output.status.success());
+    assert_eq!(
+        python_stdout.lines().collect::<Vec<_>>(),
+        [
+            "Initializing package",
+            "Running entry without package imports"
+        ],
         "Generated bundle:\n{bundled_content}"
     );
 }


### PR DESCRIPTION
## Summary

- make module registration reject an import name that resolves to a different canonical file
- propagate registration failures through module discovery instead of building contradictory resolver and graph state
- preserve same-file aliases and add regression coverage that verifies failed registration leaves all reverse mappings unchanged

## Root cause

After module identity ownership moved into `ModuleResolver`, `ModuleRegistry::register` still allocated a new `ModuleId` for a reused name with a different path while retaining the original name mapping. That allowed path and name lookups to identify different modules.

The registry now validates the name-to-path invariant before allocating an ID or mutating any map.

## Validation

- `cargo nextest run --workspace` (190 passed)
- `cargo clippy --workspace --all-targets`
- `cargo check --workspace --all-targets --features bench`

Fixes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundling and module discovery now fail fast on module registration errors instead of silently continuing.
  * Conflicting module name/path registrations are rejected to prevent inconsistent resolution.
  * Entry module handling for package `__main__.py` now correctly seeds initialization and uses the expected module naming.
* **Tests**
  * Updated unit test setup to treat module registration as fallible and assert success.
  * Added/expanded integration coverage for explicit package `__main__.py` entries, including sibling imports.
  * Added coverage for conflicting registrations failing as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->