### PR TITLE
test: make snapshot syntax gate actually validate bundled output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,8 +263,8 @@ The `--stdout` flag is particularly useful for debugging and development workflo
 # Quick inspection of bundled output without creating files
 cribo --entry main.py --stdout
 
-# Pipe to tools for analysis
-cribo --entry main.py --stdout | python -m py_compile -
+# Pipe to tools for syntax validation (py_compile cannot read source from stdin)
+cribo --entry main.py --stdout | python -c "import sys, ast; ast.parse(sys.stdin.read())"
 
 # Combine with verbose logging (logs go to stderr, code to stdout)
 cribo --entry main.py --stdout -vv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,8 +263,12 @@ The `--stdout` flag is particularly useful for debugging and development workflo
 # Quick inspection of bundled output without creating files
 cribo --entry main.py --stdout
 
-# Pipe to tools for syntax validation (py_compile cannot read source from stdin)
-cribo --entry main.py --stdout | python -c "import sys, ast; ast.parse(sys.stdin.read())"
+# Pipe to tools for syntax validation:
+# - set -o pipefail propagates a cribo failure through the pipeline
+# - compile() reads from stdin and applies full compiler checks
+#   (py_compile cannot read source from stdin; ast.parse skips semantic checks)
+set -o pipefail
+cribo --entry main.py --stdout | python -c "import sys; compile(sys.stdin.buffer.read(), '<stdin>', 'exec')"
 
 # Combine with verbose logging (logs go to stderr, code to stdout)
 cribo --entry main.py --stdout -vv

--- a/crates/cribo/tests/test_bundling_snapshots.rs
+++ b/crates/cribo/tests/test_bundling_snapshots.rs
@@ -342,12 +342,28 @@ fn test_bundling_fixtures() {
         };
 
         // Validate Python syntax of the bundled output before execution.
-        // Note: `py_compile` cannot read from stdin (`-` is treated as a literal
-        // filename), so compile the bundled file on disk instead.
+        // Use compile() with the source piped via stdin: unlike `py_compile
+        // <file>` this writes no `__pycache__` bytecode into temp_dir (which is
+        // later the working directory for bundle execution and must stay
+        // pristine), and unlike `py_compile -` it actually reads source from
+        // stdin. compile() performs full syntax and semantic compilation
+        // checks, matching what execution would do.
         let syntax_check = Command::new(&python_cmd)
-            .args(["-m", "py_compile", bundle_path.to_str().unwrap()])
-            .output()
-            .expect("Failed to run python -m py_compile on bundled output");
+            .args([
+                "-c",
+                "import sys; compile(sys.stdin.buffer.read(), '<bundled>', 'exec')",
+            ])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                if let Some(mut stdin) = child.stdin.take() {
+                    stdin.write_all(bundled_code.as_bytes())?;
+                }
+                child.wait_with_output()
+            })
+            .expect("Failed to run Python syntax validation on bundled output");
 
         // The bundler must never emit syntactically invalid Python, regardless of
         // fixture type (xfail_/pyfail_ cover bundling/runtime failures, not

--- a/crates/cribo/tests/test_bundling_snapshots.rs
+++ b/crates/cribo/tests/test_bundling_snapshots.rs
@@ -341,26 +341,23 @@ fn test_bundling_fixtures() {
             }
         };
 
-        // Optionally validate Python syntax before execution
+        // Validate Python syntax of the bundled output before execution.
+        // Note: `py_compile` cannot read from stdin (`-` is treated as a literal
+        // filename), so compile the bundled file on disk instead.
         let syntax_check = Command::new(&python_cmd)
-            .args(["-m", "py_compile", "-"])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn();
+            .args(["-m", "py_compile", bundle_path.to_str().unwrap()])
+            .output()
+            .expect("Failed to run python -m py_compile on bundled output");
 
-        if let Ok(mut child) = syntax_check {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(bundled_code.as_bytes());
-            }
-            if let Ok(output) = child.wait_with_output()
-                && !output.status.success()
-                && env::var("RUST_TEST_VERBOSE").is_ok()
-            {
-                eprintln!("Warning: Bundled code has syntax errors for fixture {fixture_name}");
-                eprintln!("Stderr: {}", String::from_utf8_lossy(&output.stderr));
-            }
-        }
+        // The bundler must never emit syntactically invalid Python, regardless of
+        // fixture type (xfail_/pyfail_ cover bundling/runtime failures, not
+        // malformed generated code), so this is a hard failure for all fixtures.
+        assert!(
+            syntax_check.status.success(),
+            "Bundled code has invalid Python syntax for fixture '{}':\n{}",
+            fixture_name,
+            String::from_utf8_lossy(&syntax_check.stderr).trim()
+        );
 
         // Run ruff linting for cross-validation
         let ruff_results = run_ruff_lint_on_bundle(&bundled_code);


### PR DESCRIPTION
## Summary

Fixes #516

`python -m py_compile -` treats `-` as a literal filename and reads a list of filenames from stdin, so the snapshot suite's syntax gate never compiled the `bundled_code` piped to it — it exited 0 for arbitrary input (verified empirically: valid and invalid source both produced `[Errno 2] No such file or directory: '<code>'` with exit 0 when the read filename didn't exist). On top of that, failures were only printed as warnings behind `RUST_TEST_VERBOSE`.

## Changes

- `crates/cribo/tests/test_bundling_snapshots.rs`: run `py_compile` on the bundled file already written to disk, and turn syntax errors into a hard `assert!` failure for **all** fixture types — including `xfail_`/`pyfail_`, since those prefixes cover bundling/runtime failures, never malformed generated code.
- `CLAUDE.md`: replace the same broken `--stdout | python -m py_compile -` recipe with `python -c "import sys, ast; ast.parse(sys.stdin.read())"`, which actually validates stdin.

## Testing

- `cargo clippy --workspace --all-targets` clean
- Full snapshot suite passes with the gate now active: `cargo nextest run --workspace --test test_bundling_snapshots` (no existing fixture emits invalid syntax)
- Verified `python -m py_compile <file>` exits 1 on a syntactically invalid file, and that the new CLAUDE.md recipe works against a real bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened bundled-output validation to reliably detect Python syntax errors.
  * Syntax issues in generated files now cause test failures instead of warnings, improving release confidence.

* **Documentation**
  * Updated the stdout debugging example to validate emitted Python syntax more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->